### PR TITLE
redefine logging levels

### DIFF
--- a/main.js
+++ b/main.js
@@ -9,11 +9,29 @@ const platform      = require('os').platform();
 const rxIpc         = require('rx-ipc-electron/lib/main').default;
 const Observable    = require('rxjs/Observable').Observable;
 const log           = require('electron-log');
-
-log.transports.file.appName = (process.platform == 'linux' ? '.particl' : 'Particl');
-log.transports.file.file = log.transports.file
+/*
+ * Logger config
+ */
+log.transports.file.appName  = (process.platform == 'linux' ? '.particl' : 'Particl');
+log.transports.file.file     = log.transports.file
    .findLogPath(log.transports.file.appName)
    .replace('log.log', 'particl.log');
+
+log.transports.console.level = 'info';
+log.transports.file.level = 'debug';
+
+if (process.argv.includes('-v')) {
+  log.transports.console.level = 'debug'; /* most messages */
+  process.argv.push('-printtoconsole');   /* daemon output */
+}
+
+if (process.argv.includes('-vv')) {
+  log.transports.console.level = 'silly'; /* all messages      */
+  process.argv.push('-debug');            /* daemon debug mode */
+}
+log.daemon = log.info;
+console.log(log);
+
 log.debug(`console log level: ${log.transports.console.level}`);
 log.debug(   `file log level: ${log.transports.file.level   }`);
 
@@ -36,7 +54,7 @@ if (process.argv.includes('-opendevtools'))
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.on('ready', () => {
-  log.debug('app ready')
+  log.info('app ready')
   options = _options.parse();
   initMainWindow();
   init.start(mainWindow);

--- a/modules/clientBinaries/clientBinariesManager.js
+++ b/modules/clientBinaries/clientBinariesManager.js
@@ -108,7 +108,7 @@ class Manager {
    * @return {Promise}
    */
   init(options) {
-    this._logger.info('Initializing Manager...');
+    this._logger.debug('Initializing Manager...');
 
     this._resolvePlatform();
 
@@ -196,7 +196,7 @@ class Manager {
 
       const downloadFile = path.join(downloadFolder, `archive.${downloadCfg.type}`);
 
-      this._logger.info(`Downloading package from ${downloadCfg.url} to ${downloadFile} ...`);
+      this._logger.debug(`Downloading package from ${downloadCfg.url} to ${downloadFile} ...`);
 
       const writeStream = fs.createWriteStream(downloadFile);
 
@@ -357,14 +357,13 @@ class Manager {
       })
       .then(() => {
         info.client = client;
-
         return info;
       });
     });
   }
 
   _resolvePlatform () {
-    this._logger.info('Resolving platform...');
+    this._logger.debug('Resolving platform...');
 
     // platform
     switch (process.platform) {
@@ -403,13 +402,13 @@ class Manager {
 
       const count = Object.keys(this._clients).length;
 
-      this._logger.info(`${count} possible clients.`);
+      this._logger.debug(`${count} possible clients.`);
 
       if (_.isEmpty(this._clients)) {
         return;
       }
 
-      this._logger.info(`Verifying status of all ${count} possible clients...`);
+      this._logger.debug(`Verifying status of all ${count} possible clients...`);
 
       return Promise.all(_.values(this._clients).map(
         (client) => this._verifyClientStatus(client, options)
@@ -425,7 +424,7 @@ class Manager {
     return Promise.resolve()
     .then(() => {
       // get possible clients
-      this._logger.info('Calculating possible clients...');
+      this._logger.debug('Calculating possible clients...');
 
       const possibleClients = {};
 
@@ -458,7 +457,7 @@ class Manager {
       folders: []
     }, options);
 
-    this._logger.info(`Verify ${client.id} status ...`);
+    this._logger.debug(`Verify ${client.id} status ...`);
 
     return Promise.resolve().then(() => {
       const binName = client.activeCli.bin;
@@ -569,7 +568,7 @@ class Manager {
   _runSanityCheck (client, binPath) {
     this._logger.debug(`${client.id} binary path: ${binPath}`);
 
-    this._logger.info(`Checking for ${client.id} sanity check ...`);
+    this._logger.debug(`Checking for ${client.id} sanity check ...`);
 
     const sanityCheck = _.get(client, 'activeCli.commands.sanity');
 
@@ -580,7 +579,7 @@ class Manager {
       }
     })
     .then(() => {
-      this._logger.info(`Checking sanity for ${client.id} ...`)
+      this._logger.debug(`Checking sanity for ${client.id} ...`)
 
       return this._spawn(binPath, sanityCheck.args);
     })
@@ -597,7 +596,7 @@ class Manager {
         }
       }
 
-      this._logger.debug(`Sanity check passed for ${binPath}`);
+      this._logger.info(`Sanity check passed for ${binPath}`);
 
       // set it!
       client.activeCli.fullPath = binPath;

--- a/modules/daemon/daemon.js
+++ b/modules/daemon/daemon.js
@@ -14,9 +14,17 @@ let exitCode = 0;
 let restarting = false;
 let chosenWallets = [];
 
-// TODO: log properly on console and to file [ -- -printtoconsole ]
+// TODO: for proper logging, parse data to single line entries without date.
 function daemonData(data, logger) {
-  logger(data.toString().trim());
+  data = data.toString().trim();
+  // data = data.split(' ').splice(2);
+  // data.map(chunk => {
+  //   while (newline = chunk.indexOf('\n')) {
+  //     let out = splice(0, newline);
+  //     log.info(out);
+  //   }
+  // })
+  logger(data);
 }
 
 exports.restart = function (cb) {
@@ -59,9 +67,8 @@ exports.start = function (wallets, callback) {
 
     }).catch(() => {
 
-      // TODO: only for some debug levels
-      // if (!restarting)
-        // process.argv.push('-printtoconsole');
+      if (!restarting && ['debug', 'silly'].includes(log.transports.console.level))
+        process.argv.push('-printtoconsole');
 
       wallets = wallets.map(wallet => `-wallet=${wallet}`);
       log.info(`starting daemon ${daemonPath} ${process.argv} ${wallets}`);

--- a/modules/daemon/daemonManager.js
+++ b/modules/daemon/daemonManager.js
@@ -298,7 +298,7 @@ class DaemonManager extends EventEmitter {
 
 
   _resolveBinPath() {
-    log.info('Resolving path to client binary ...');
+    log.debug('Resolving path to client binary ...');
 
     let platform = process.platform;
 
@@ -317,7 +317,7 @@ class DaemonManager extends EventEmitter {
       binPath += '.exe';
     }
 
-    log.info(`Client binary path: ${binPath}`);
+    log.debug(`Client binary path: ${binPath}`);
 
     this._availableClients.particld = {
       binPath


### PR DESCRIPTION
Following #344 logging levels (info, debug, error...) have been redefined.

Instead of using `-printtoconsole` and `-debug`, you can now simply use `-v` and `-vv`