### PR TITLE
Update Git Release URL #735

### DIFF
--- a/src/app/core-ui/main/release-notification/release-notification.component.ts
+++ b/src/app/core-ui/main/release-notification/release-notification.component.ts
@@ -23,7 +23,7 @@ export class ReleaseNotificationComponent implements OnInit {
   }
 
   getCurrentClientVersion() {
-    this.http.get('https://api.github.com/repos/particl/partgui/releases/latest').subscribe((response: ReleaseNotification) => {
+    this.http.get('https://api.github.com/repos/particl/particl-desktop/releases/latest').subscribe((response: ReleaseNotification) => {
       if (response.tag_name) {
         this.latestClientVersion = response.tag_name.substring(1);
       }


### PR DESCRIPTION
For checking new update API calls every time on git repository after changing git repo URL it will not work so that should be updated if repository updated.