### PR TITLE
TX confirmation modal 2.0

### DIFF
--- a/modules/options.js
+++ b/modules/options.js
@@ -33,13 +33,18 @@ exports.parse = function() {
     process.argv = process.argv.splice(1); /* striping /path/to/particl from argv */
   }
 
-  process.argv.map((arg, index) => {
+  // make a copy of process.argv, because we'll be changing it
+  // which messes with the map operator
+  const args = process.argv.slice(0); 
 
+  args.map((arg, index) => {
     let nDashes = arg.lastIndexOf('-') + 1;
+    const argIndex = process.argv.indexOf(arg);
     arg = arg.substr(nDashes);
 
     if (nDashes === 2) { /* double-dash: desktop-only argument */
-      process.argv.splice(process.argv.indexOf(arg), 1);
+      // delete param, so it doesn't get passed to particl-core
+      process.argv.splice(argIndex, 1);
       let verboseLevel = isVerboseLevel(arg);
       if (verboseLevel) {
         options['verbose'] = verboseLevel;

--- a/src/app/_test/wallet-test/send-test/send-mock.service.ts
+++ b/src/app/_test/wallet-test/send-test/send-mock.service.ts
@@ -1,0 +1,15 @@
+import { Observable } from 'rxjs/Observable';
+import { Injectable } from '@angular/core';
+
+const SendService_OBJECT: any = {file: {}};
+
+@Injectable()
+export class SendMockService {
+
+  constructor() { }
+
+  public getTransactionFee(): Observable<any> {
+    return Observable.of(SendService_OBJECT);
+  }
+
+}

--- a/src/app/core/state/state.service.ts
+++ b/src/app/core/state/state.service.ts
@@ -6,7 +6,7 @@ import { Observer } from 'rxjs/Rx';
 
 export interface InternalStateType {
   [key: string]: any;
-};
+}
 
 interface InternalStateCache {
   [key: string]: {

--- a/src/app/core/util/utils.ts
+++ b/src/app/core/util/utils.ts
@@ -8,6 +8,11 @@ export class Amount {
     return this.amount;
   }
 
+  public getAmountWithFee(fee: number) {
+    const total = this.amount + fee;
+    return this.truncateToDecimals(total, 8);
+  }
+
   /**
    * Returns integer part.
    * e.g:

--- a/src/app/core/util/utils.ts
+++ b/src/app/core/util/utils.ts
@@ -88,6 +88,26 @@ export class Amount {
 
 }
 
+export class Fee {
+  constructor(private fee: number) {
+    this.fee = this.truncateToDecimals(fee, 8);
+  }
+
+  public getFee(): number {
+    return this.fee;
+  }
+
+  public getAmountWithFee(amount: number): number {
+    const total = this.fee + amount;
+    return this.truncateToDecimals(total, 8);
+  }
+
+  truncateToDecimals(int: number, dec: number): number {
+    const calcDec = Math.pow(10, dec);
+    return Math.trunc(int * calcDec) / calcDec;
+  }
+}
+
 export class Duration {
 
   constructor(private duration: number) {

--- a/src/app/core/util/utils.ts
+++ b/src/app/core/util/utils.ts
@@ -156,6 +156,12 @@ export class AddressHelper {
     ? 'addressPublicRegex' : 'addressPrivateRegex' : 'addressBothRegex')].test(address);
   }
 
+  getAddressType(address: string): string {
+    return (this.testAddress(address) ?
+      (this.testAddress(address, 'public') ? 'public' : 'private') :
+      '');
+  }
+
   getAddress(address: string): string {
     const match = address.match(this.addressBothRegex);
     return match ? match[0] : null;

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
@@ -6,7 +6,7 @@
 <div mat-dialog-content class="dialog-content">
   <div class="tx-info">
     <!-- if public -->
-    <div class="public" *ngIf="transactionType === 'balance'">
+    <div class="public" *ngIf="transactionType === 'part'">
       <mat-icon class="icon public" fontSet="partIcon" fontIcon="part-public"></mat-icon>
       <div class="title">Public transaction</div>
       <p class="help-text">
@@ -14,14 +14,14 @@
       </p>
     </div>
     <!-- if blind / anon-->
-    <div class="blind" *ngIf="transactionType === 'blind_balance'">
+    <div class="blind" *ngIf="transactionType === 'blind'">
       <mat-icon class="icon public" fontSet="partIcon" fontIcon="part-blind"></mat-icon>
       <div class="title">Blind transaction</div>
       <p class="help-text">
         Sender & Receiver will be publicly visible on the blockchain, but the transaction amount will be hidden
       </p>
     </div>
-    <div class="anon" *ngIf="transactionType === 'anon_balance'">
+    <div class="anon" *ngIf="transactionType === 'anon'">
       <mat-icon class="icon public" fontSet="partIcon" fontIcon="part-anon"></mat-icon>
       <div class="title">Anon transaction</div>
       <p class="help-text">
@@ -45,6 +45,7 @@
   <div class="receiver-info">
     <!--if address saved in Address Book, display its label. if not, hide it -->
     <div class="label" *ngIf="receiverName !== ''">{{ receiverName }}</div>
+    <div class="label" *ngIf="!sendAddress">Balance Transfer</div>
     <code class="address"> {{ sendAddress }} </code>
   </div>
 

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
@@ -3,7 +3,7 @@
   <mat-icon fontSet="partIcon" fontIcon="part-circle-remove"></mat-icon>
 </button>
 
-<div mat-dialog-content class="dialog-content">  
+<div mat-dialog-content class="dialog-content">
   <div class="tx-info">
     <!-- if public -->
     <div class="public" *ngIf="transactionType === 'balance'">
@@ -31,7 +31,9 @@
   </div>
 
   <div class="tx-amount">
-    <span class="big">{{ sendAmount.getIntegerPart() }}</span><span class="point">.</span><span class="small">{{ sendAmount.getFractionalPart() }}</span>&ensp;<span class="currency">PART</span>
+    <span class="big">{{ sendAmount.getIntegerPart() }}</span>
+    <span class="point">.</span><span class="small">{{ sendAmount.getFractionalPart() }}</span>&ensp;
+    <span class="currency">PART</span>
     <!-- TODO: until fiat estimations are implemented, hide them -->
     <div class="fiat">&asymp; 3.42 USD</div>
   </div>
@@ -44,9 +46,9 @@
     <code class="address"> {{ sendAddress }} </code>
   </div>
 
-  <p class="fee-info TO_DO">
-    Transaction fee:<span class="amount">0.000152 PART</span><span class="fiat">&asymp; 0.05 USD</span><br>
-    Total amount:<span class="amount">12.723552 PART</span><span class="fiat">&asymp; 3.47 USD</span>
+  <p class="fee-info">
+    Transaction fee:<span class="amount">{{transactionFee}} PART</span><span class="fiat">&asymp; 0.05 USD</span><br>
+    Total amount:<span class="amount">{{totalAmount}} PART</span><span class="fiat">&asymp; 3.47 USD</span>
   </p>
 
 </div>

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
@@ -3,31 +3,27 @@
   <mat-icon fontSet="partIcon" fontIcon="part-circle-remove"></mat-icon>
 </button>
 
-<div mat-dialog-content class="dialog-content">
-  
-  <!-- FIXME: original dialog content just for reference, can be removed afterwards -->
-  {{dialogContent}}
-  
-  <!-- FIXME: this is just a static template. All needs to be connected to backend! -->
+<div mat-dialog-content class="dialog-content">  
   <div class="tx-info">
-    <!-- TODO: if public -->
-    <div class="public">
+    <!-- if public -->
+    <div class="public" *ngIf="transactionType === 'public'">
       <mat-icon class="icon public" fontSet="partIcon" fontIcon="part-public"></mat-icon>
       <div class="title">Public transaction</div>
       <p class="help-text">
         Sender, Receiver & transaction amount will be publicly visible on the blockchain
       </p>
     </div>
-    <!-- TODO: if blind -->
-    <!--div class="blind">
+    <!-- if blind / anon-->
+    <div class="blind" *ngIf="transactionType === 'private'">
       <mat-icon class="icon public" fontSet="partIcon" fontIcon="part-blind"></mat-icon>
-      <div class="title">Blind transaction</div>
+      <div class="title">Blind / Anon transaction</div>
       <p class="help-text">
         Sender & Receiver will be publicly visible on the blockchain, but the transaction amount will be hidden
       </p>
-    </div-->
+    </div>
+    <!-- Cant deferinciate between blind, anon as the adress regex is the same-->
     <!-- TODO: if anon -->
-    <!--div class="anon">
+    <!--div class="anon" *nfif="transactionType === 'blind'">
       <mat-icon class="icon public" fontSet="partIcon" fontIcon="part-anon"></mat-icon>
       <div class="title">Anon transaction</div>
       <p class="help-text">
@@ -37,7 +33,7 @@
   </div>
 
   <div class="tx-amount">
-    <span class="big">12</span><span class="point">.</span><span class="small">7234</span>&ensp;<span class="currency">PART</span>
+    <span class="big">{{ sendAmount.getIntegerPart() }}</span><span class="point">.</span><span class="small">{{ sendAmount.getFractionalPart() }}</span>&ensp;<span class="currency">PART</span>
     <!-- TODO: until fiat estimations are implemented, hide them -->
     <div class="fiat">&asymp; 3.42 USD</div>
   </div>
@@ -45,9 +41,9 @@
   <mat-icon class="icon arrow" fontSet="partIcon" fontIcon="part-arrow-down"></mat-icon>
 
   <div class="receiver-info">
-    <!-- FIXME: if address saved in Address Book, display its label. if not, hide it -->
-    <div class="label">Allien (Copay)</div>
-    <code class="address">piHvjzDdiykKN5r5E3eVLtX4cYVhgFwNG4</code>
+    <!--if address saved in Address Book, display its label. if not, hide it -->
+    <div class="label" *ngIf="receiverName !== ''">{{ receiverName }}</div>
+    <code class="address"> {{ sendAddress }} </code>
   </div>
 
   <p class="fee-info">

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
@@ -44,7 +44,7 @@
     <code class="address"> {{ sendAddress }} </code>
   </div>
 
-  <p class="fee-info">
+  <p class="fee-info TO_DO">
     Transaction fee:<span class="amount">0.000152 PART</span><span class="fiat">&asymp; 0.05 USD</span><br>
     Total amount:<span class="amount">12.723552 PART</span><span class="fiat">&asymp; 3.47 USD</span>
   </p>

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
@@ -32,7 +32,9 @@
 
   <div class="tx-amount">
     <span class="big">{{ sendAmount.getIntegerPart() }}</span>
-    <span class="point">.</span><span class="small">{{ sendAmount.getFractionalPart() }}</span>&ensp;
+    <span *ngIf="sendAmount.ifDotExist()">
+      <span class="point">.</span>
+      <span class="small">{{ sendAmount.getFractionalPart() }}</span>&ensp;</span>
     <span class="currency">PART</span>
     <!-- TODO: until fiat estimations are implemented, hide them -->
     <div class="fiat">&asymp; 3.42 USD</div>

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
@@ -16,7 +16,7 @@
     <!-- if blind / anon-->
     <div class="blind" *ngIf="transactionType === 'blind_balance'">
       <mat-icon class="icon public" fontSet="partIcon" fontIcon="part-blind"></mat-icon>
-      <div class="title">Blind / Anon transaction</div>
+      <div class="title">Blind transaction</div>
       <p class="help-text">
         Sender & Receiver will be publicly visible on the blockchain, but the transaction amount will be hidden
       </p>

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
@@ -49,8 +49,8 @@
   </div>
 
   <p class="fee-info">
-    Transaction fee:<span class="amount">{{transactionFee}} PART</span><span class="fiat">&asymp; 0.05 USD</span><br>
-    Total amount:<span class="amount">{{totalAmount}} PART</span><span class="fiat">&asymp; 3.47 USD</span>
+    Transaction fee:<span class="amount">{{ transactionFee }} PART</span><span class="fiat">&asymp; 0.05 USD</span><br>
+    Total amount:<span class="amount">{{ sendAmount.getAmountWithFee(transactionFee) }} PART</span><span class="fiat">&asymp; 3.47 USD</span>
   </p>
 
 </div>

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
@@ -21,7 +21,7 @@
         Sender & Receiver will be publicly visible on the blockchain, but the transaction amount will be hidden
       </p>
     </div>
-    <div class="anon" *nfif="transactionType === 'anon'">
+    <div class="anon" *ngIf="transactionType === 'anon'">
       <mat-icon class="icon public" fontSet="partIcon" fontIcon="part-anon"></mat-icon>
       <div class="title">Anon transaction</div>
       <p class="help-text">

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
@@ -6,7 +6,7 @@
 <div mat-dialog-content class="dialog-content">  
   <div class="tx-info">
     <!-- if public -->
-    <div class="public" *ngIf="transactionType === 'public'">
+    <div class="public" *ngIf="transactionType === 'balance'">
       <mat-icon class="icon public" fontSet="partIcon" fontIcon="part-public"></mat-icon>
       <div class="title">Public transaction</div>
       <p class="help-text">
@@ -14,14 +14,14 @@
       </p>
     </div>
     <!-- if blind / anon-->
-    <div class="blind" *ngIf="transactionType === 'blind'">
+    <div class="blind" *ngIf="transactionType === 'blind_balance'">
       <mat-icon class="icon public" fontSet="partIcon" fontIcon="part-blind"></mat-icon>
       <div class="title">Blind / Anon transaction</div>
       <p class="help-text">
         Sender & Receiver will be publicly visible on the blockchain, but the transaction amount will be hidden
       </p>
     </div>
-    <div class="anon" *ngIf="transactionType === 'anon'">
+    <div class="anon" *ngIf="transactionType === 'anon_balance'">
       <mat-icon class="icon public" fontSet="partIcon" fontIcon="part-anon"></mat-icon>
       <div class="title">Anon transaction</div>
       <p class="help-text">

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
@@ -2,8 +2,58 @@
 <button class="small-close_button pull-right" (click)="dialogClose()">
   <mat-icon fontSet="partIcon" fontIcon="part-circle-remove"></mat-icon>
 </button>
+
 <div mat-dialog-content class="dialog-content">
-  {{dialogContent}}
+  <!-- FIXME: this is just a static template. All needs to be connected to backend! -->
+
+  <div class="tx-info">
+    <!-- TODO: if public -->
+    <div class="public">
+      <mat-icon class="icon public" fontSet="partIcon" fontIcon="part-public"></mat-icon>
+      <div class="title">Public transaction</div>
+      <p class="help-text">
+        Sender, Receiver & transaction amount will be publicly visible on the blockchain
+      </p>
+    </div>
+    <!-- TODO: if blind -->
+    <!--div class="blind">
+      <mat-icon class="icon public" fontSet="partIcon" fontIcon="part-blind"></mat-icon>
+      <div class="title">Blind transaction</div>
+      <p class="help-text">
+        Sender & Receiver will be publicly visible on the blockchain, but the transaction amount will be hidden
+      </p>
+    </div-->
+    <!-- TODO: if anon -->
+    <!--div class="anon">
+      <mat-icon class="icon public" fontSet="partIcon" fontIcon="part-anon"></mat-icon>
+      <div class="title">Anon transaction</div>
+      <p class="help-text">
+        Sender, Receiver & transaction amount will be hidden on the blockchain for highest privacy
+      </p>
+    </div-->
+  </div>
+
+  <div class="tx-amount">
+    <span class="big">12</span><span class="point">.</span><span class="small">7234</span>&ensp;<span class="currency">PART</span>
+    <!-- TODO: until fiat estimations are implemented, hide them -->
+    <div class="fiat">&asymp; 3.42 USD</div>
+  </div>
+
+  <mat-icon class="icon arrow" fontSet="partIcon" fontIcon="part-arrow-down"></mat-icon>
+
+  <div class="receiver-info">
+    <!-- FIXME: if address saved in Address Book, display its label. if not, hide it -->
+    <div class="label">Crz (priv)</div>
+    <code class="address">TetdMHVqfefdFW8r8B8Cy93yYbo7qRbVPJNfnEg6kBQdegcAjX1a3B9Z1EZw2E9vznsooyMNV5TmB7k7e79MUS8WYqKXo9q3BnydDj</code>
+  </div>
+
+  <p class="fee-info">
+    Transaction fee:<span class="amount">0.000152 PART</span><span class="fiat">&asymp; 0.05 USD</span><br>
+    Total amount:<span class="amount">12.723552 PART</span><span class="fiat">&asymp; 3.47 USD</span>
+  </p>
+
+  <!-- FIXME: original dialog content just for reference, can be removed afterwards -->
+  <p style="opacity: 0.2">{{dialogContent}}</p>
 </div>
 
 <mat-dialog-actions fxLayoutAlign="end center">

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
@@ -14,22 +14,20 @@
       </p>
     </div>
     <!-- if blind / anon-->
-    <div class="blind" *ngIf="transactionType === 'private'">
+    <div class="blind" *ngIf="transactionType === 'blind'">
       <mat-icon class="icon public" fontSet="partIcon" fontIcon="part-blind"></mat-icon>
       <div class="title">Blind / Anon transaction</div>
       <p class="help-text">
         Sender & Receiver will be publicly visible on the blockchain, but the transaction amount will be hidden
       </p>
     </div>
-    <!-- Cant deferinciate between blind, anon as the adress regex is the same-->
-    <!-- TODO: if anon -->
-    <!--div class="anon" *nfif="transactionType === 'blind'">
+    <div class="anon" *nfif="transactionType === 'anon'">
       <mat-icon class="icon public" fontSet="partIcon" fontIcon="part-anon"></mat-icon>
       <div class="title">Anon transaction</div>
       <p class="help-text">
         Sender, Receiver & transaction amount will be hidden on the blockchain for highest privacy
       </p>
-    </div-->
+    </div>
   </div>
 
   <div class="tx-amount">

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
@@ -4,8 +4,11 @@
 </button>
 
 <div mat-dialog-content class="dialog-content">
+  
+  <!-- FIXME: original dialog content just for reference, can be removed afterwards -->
+  {{dialogContent}}
+  
   <!-- FIXME: this is just a static template. All needs to be connected to backend! -->
-
   <div class="tx-info">
     <!-- TODO: if public -->
     <div class="public">
@@ -43,8 +46,8 @@
 
   <div class="receiver-info">
     <!-- FIXME: if address saved in Address Book, display its label. if not, hide it -->
-    <div class="label">Crz (priv)</div>
-    <code class="address">TetdMHVqfefdFW8r8B8Cy93yYbo7qRbVPJNfnEg6kBQdegcAjX1a3B9Z1EZw2E9vznsooyMNV5TmB7k7e79MUS8WYqKXo9q3BnydDj</code>
+    <div class="label">Allien (Copay)</div>
+    <code class="address">piHvjzDdiykKN5r5E3eVLtX4cYVhgFwNG4</code>
   </div>
 
   <p class="fee-info">
@@ -52,8 +55,6 @@
     Total amount:<span class="amount">12.723552 PART</span><span class="fiat">&asymp; 3.47 USD</span>
   </p>
 
-  <!-- FIXME: original dialog content just for reference, can be removed afterwards -->
-  <p style="opacity: 0.2">{{dialogContent}}</p>
 </div>
 
 <mat-dialog-actions fxLayoutAlign="end center">

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.html
@@ -50,8 +50,8 @@
   </div>
 
   <p class="fee-info">
-    Transaction fee:<span class="amount">{{ transactionFee }} PART</span><span class="fiat">&asymp; 0.05 USD</span><br>
-    Total amount:<span class="amount">{{ sendAmount.getAmountWithFee(transactionFee) }} PART</span><span class="fiat">&asymp; 3.47 USD</span>
+    Transaction fee:<span class="amount">{{ transactionAmount.getFee() }} PART</span><span class="fiat">&asymp; 0.05 USD</span><br>
+    Total amount:<span class="amount">{{ transactionAmount.getAmountWithFee(sendAmount.getAmount()) }} PART</span><span class="fiat">&asymp; 3.47 USD</span>
   </p>
 
 </div>

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.scss
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.scss
@@ -1,5 +1,8 @@
 @import "./src/assets/_config"; // import shared colors etc.
 
+.fiat {
+  display: none; // hide until implemented (TODO)
+}
 
 // ------ UI ------ //
 
@@ -57,7 +60,6 @@
     font-size: 17px;
   }
   & > .fiat {
-    display: none;
     color: $text-muted;
   }
 }
@@ -91,7 +93,6 @@
 }
 
 .fee-info {
-  display: none;
   // FIXME: switch to: @extend %help-text;
   @extend %disable-select;
   color: $text-muted;

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.scss
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.scss
@@ -1,0 +1,101 @@
+@import "./src/assets/_config"; // import shared colors etc.
+
+
+// ------ UI ------ //
+
+.title {
+  // FIXME: swith to @extend %box-title;
+  text-transform: uppercase;
+  font-weight: bold;
+  font-size: 13px;
+}
+
+.help-text {
+  // FIXME: switch to: @extend %help-text;
+  @extend %disable-select;
+  color: $text-muted;
+  font-size: 11px;
+  margin-bottom: 25px;
+  cursor: help;
+}
+
+
+// ------ LAYOUT ------ //
+
+.dialog-content {
+  width: 25rem;
+  padding: 20px 15px 10px;
+  text-align: center;
+}
+
+.tx-info { // info about public/blind/anon TX
+  @extend %disable-select;
+  .icon {
+    width: auto;
+    height: auto;
+    font-size: 32px;
+    color: $color;
+  }
+  .help-text {
+    margin: 5px auto 20px;
+    max-width: 20rem;
+  }
+}
+
+.tx-amount {
+  & > .big {
+    font-size: 20px;
+  }
+  & > .small {
+    font-size: 14px;
+  }
+  & > .point {
+    font-weight: bold;
+    margin: 0 2px;
+  }
+  & > .currency {
+    font-size: 17px;
+  }
+  & > .fiat {
+    color: $text-muted;
+  }
+}
+
+.icon.arrow {
+  font-size: 18px;
+  width: auto;
+  height: auto;
+  margin: 24px 0;
+  color: mix($text-muted, $bg-shadow);
+}
+
+.receiver-info {
+  & > .label {
+    font-weight: bold;
+    font-size: 16px;
+    margin-bottom: 8px;
+  }
+  & > .address {
+    display: inline-block;
+    max-width: 270px;
+    padding: 3px 8px;
+    background: $bg;
+    border-radius: 4px;
+    color: mix($text, $text-muted);
+    font-size: 13px;
+    line-height: 1.4;
+    white-space: normal;
+    word-wrap: break-word;
+  }
+}
+
+.fee-info {
+  // FIXME: switch to: @extend %help-text;
+  @extend %disable-select;
+  color: $text-muted;
+  font-size: 11px;
+  margin: 30px 0 0;
+  & > .amount {
+    margin: 0 5px;
+  }
+}

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.scss
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.scss
@@ -57,6 +57,7 @@
     font-size: 17px;
   }
   & > .fiat {
+    display: none;
     color: $text-muted;
   }
 }
@@ -90,6 +91,7 @@
 }
 
 .fee-info {
+  display: none;
   // FIXME: switch to: @extend %help-text;
   @extend %disable-select;
   color: $text-muted;

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.spec.ts
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.spec.ts
@@ -4,6 +4,8 @@ import { MatDialogRef, MatFormFieldModule } from '@angular/material';
 
 import { MaterialModule } from '../../../../core-ui/material/material.module';
 
+import { SendService } from '../send.service';
+
 import { SendConfirmationModalComponent } from './send-confirmation-modal.component';
 
 describe('SendConfirmationModalComponent', () => {
@@ -19,7 +21,8 @@ describe('SendConfirmationModalComponent', () => {
       ],
       declarations: [ SendConfirmationModalComponent ],
       providers: [
-        { provide: MatDialogRef}
+        { provide: MatDialogRef},
+        SendService
       ]
     })
     .compileComponents();

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.spec.ts
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.spec.ts
@@ -2,8 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { CommonModule } from '@angular/common';
 import { MatDialogRef, MatFormFieldModule } from '@angular/material';
 
-import { CoreModule } from '../../../../core/core.module';
-import { CoreUiModule } from '../../../../core-ui/core-ui.module';
+import { MaterialModule } from '../../../../core-ui/material/material.module';
 
 import { SendConfirmationModalComponent } from './send-confirmation-modal.component';
 
@@ -15,8 +14,7 @@ describe('SendConfirmationModalComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         CommonModule,
-        CoreModule.forRoot(),
-        CoreUiModule.forRoot(),
+        MaterialModule,
         MatFormFieldModule // check if this is required. If so, move into CoreUi.
       ],
       declarations: [ SendConfirmationModalComponent ],

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.spec.ts
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.spec.ts
@@ -1,15 +1,15 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { CommonModule } from '@angular/common';
 import { MatDialogRef, MatFormFieldModule } from '@angular/material';
-
 import { MaterialModule } from '../../../../core-ui/material/material.module';
 
 import { SendService } from '../send.service';
+import { SnackbarService } from '../../../../core/snackbar/snackbar.service';
 
 import { SendConfirmationModalComponent } from './send-confirmation-modal.component';
-import { RpcMockService } from '../../../../_test/core-test/rpc-test/rpc-mock.service';
-import { RpcService } from '../../../../core/rpc/rpc.service';
-import { SnackbarService } from '../../../../core/snackbar/snackbar.service';
+import { TransactionBuilder } from '../transaction-builder.model';
+
+import { SendMockService } from '../../../../_test/wallet-test/send-test/send-mock.service';
 
 fdescribe('SendConfirmationModalComponent', () => {
   let component: SendConfirmationModalComponent;
@@ -25,8 +25,7 @@ fdescribe('SendConfirmationModalComponent', () => {
       declarations: [ SendConfirmationModalComponent ],
       providers: [
         SnackbarService,
-        {provide: RpcService, useClass: RpcMockService},
-        SendService,
+        {provide: SendService, useClass: SendMockService},
         { provide: MatDialogRef},
       ],
     })
@@ -36,6 +35,7 @@ fdescribe('SendConfirmationModalComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(SendConfirmationModalComponent);
     component = fixture.componentInstance;
+    component.send = new TransactionBuilder();
     fixture.detectChanges();
   });
 

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.spec.ts
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.spec.ts
@@ -7,8 +7,11 @@ import { MaterialModule } from '../../../../core-ui/material/material.module';
 import { SendService } from '../send.service';
 
 import { SendConfirmationModalComponent } from './send-confirmation-modal.component';
+import { RpcMockService } from '../../../../_test/core-test/rpc-test/rpc-mock.service';
+import { RpcService } from '../../../../core/rpc/rpc.service';
+import { SnackbarService } from '../../../../core/snackbar/snackbar.service';
 
-describe('SendConfirmationModalComponent', () => {
+fdescribe('SendConfirmationModalComponent', () => {
   let component: SendConfirmationModalComponent;
   let fixture: ComponentFixture<SendConfirmationModalComponent>;
 
@@ -21,9 +24,11 @@ describe('SendConfirmationModalComponent', () => {
       ],
       declarations: [ SendConfirmationModalComponent ],
       providers: [
+        SnackbarService,
+        {provide: RpcService, useClass: RpcMockService},
+        SendService,
         { provide: MatDialogRef},
-        SendService
-      ]
+      ],
     })
     .compileComponents();
   }));

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.ts
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.ts
@@ -16,7 +16,7 @@ export class SendConfirmationModalComponent {
 
   // send-confirmation-modal variables
   transactionType: string = '';
-  sendAmount: Amount;
+  sendAmount: Amount = new Amount(0);
   sendAddress: string = '';
   receiverName: string = '';
   transactionFee: number = 0;

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.ts
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.ts
@@ -58,6 +58,7 @@ export class SendConfirmationModalComponent implements OnInit {
 
   getTransactionFee() {
     this.sendService.getTransactionFee(this.send).subscribe(fee => {
+      console.log('@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@feeeeee', fee);
       this.transactionFee = fee.fee
     });
   }

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.ts
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.ts
@@ -1,6 +1,10 @@
 import { Component, EventEmitter, Output } from '@angular/core';
 import { MatDialogRef } from '@angular/material';
 
+import { AddressHelper } from '../../../../wallet/shared/util/utils'
+
+import { Amount } from '../../../shared/util/utils';
+
 @Component({
   selector: 'app-send-confirmation-modal',
   templateUrl: './send-confirmation-modal.component.html',
@@ -12,7 +16,19 @@ export class SendConfirmationModalComponent {
 
   public dialogContent: string;
 
-  constructor(private dialogRef: MatDialogRef<SendConfirmationModalComponent>) {
+  // components
+  private addressHelper: AddressHelper;
+
+  // send-confirmation-modal variables
+  transactionType: string = '';
+  sendAmount: Amount;
+  sendAddress: string = '';
+  receiverName: string = '';
+  transactionFee: number = 0;
+  totalAmount: number = 0;
+
+  constructor(private diloagRef: MatDialogRef<SendConfirmationModalComponent>) {
+    this.addressHelper = new AddressHelper();
   }
 
   confirm(): void {
@@ -21,7 +37,21 @@ export class SendConfirmationModalComponent {
   }
 
   dialogClose(): void {
-    this.dialogRef.close();
+    this.diloagRef.close();
+  }
+
+  /**
+    * Set the modal details
+    * TODO: Create proper Interface for `send` parameter
+    */
+  setDetails(send: any): void {
+    this.sendAddress = send.toAddress;
+    this.transactionType = this.addressHelper.getAddressType(this.sendAddress);
+    this.sendAmount = new Amount(send.amount);
+    this.receiverName = send.toLabel;
+    this.transactionFee = 0;
+    this.totalAmount = send.amount;
+    console.log(this.transactionType);
   }
 
 }

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.ts
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.ts
@@ -53,7 +53,6 @@ export class SendConfirmationModalComponent implements OnInit {
     this.transactionType = this.send.input;
     this.sendAmount = new Amount(this.send.amount);
     this.receiverName = this.send.toLabel;
-    console.log(this.transactionType);
   }
 
   getTransactionFee() {

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.ts
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.ts
@@ -58,7 +58,6 @@ export class SendConfirmationModalComponent implements OnInit {
 
   getTransactionFee() {
     this.sendService.getTransactionFee(this.send).subscribe(fee => {
-      console.log('@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@feeeeee', fee);
       this.transactionFee = fee.fee
     });
   }

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.ts
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.ts
@@ -22,7 +22,7 @@ export class SendConfirmationModalComponent {
   transactionFee: number = 0;
   totalAmount: number = 0;
 
-  constructor(private dialogRef: MatDialogRef<SendConfirmationModalComponent>) { 
+  constructor(private dialogRef: MatDialogRef<SendConfirmationModalComponent>) {
   }
 
   confirm(): void {

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.ts
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.ts
@@ -3,7 +3,7 @@ import { MatDialogRef } from '@angular/material';
 
 import { SendService } from '../send.service';
 
-import { Amount } from '../../../shared/util/utils';
+import { Amount } from '../../../../core/util/utils';
 import { TransactionBuilder } from '../transaction-builder.model';
 
 @Component({

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.ts
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.ts
@@ -3,7 +3,7 @@ import { MatDialogRef } from '@angular/material';
 
 import { SendService } from '../send.service';
 
-import { Amount } from '../../../../core/util/utils';
+import { Amount, Fee } from '../../../../core/util/utils';
 import { TransactionBuilder } from '../transaction-builder.model';
 
 @Component({
@@ -23,8 +23,7 @@ export class SendConfirmationModalComponent implements OnInit {
   sendAmount: Amount = new Amount(0);
   sendAddress: string = '';
   receiverName: string = '';
-  transactionFee: number = 0;
-  totalAmount: number = 0;
+  transactionAmount: Fee = new Fee(0);
 
   constructor(private dialogRef: MatDialogRef<SendConfirmationModalComponent>,
               private sendService: SendService) {
@@ -57,7 +56,7 @@ export class SendConfirmationModalComponent implements OnInit {
 
   getTransactionFee() {
     this.sendService.getTransactionFee(this.send).subscribe(fee => {
-      this.transactionFee = fee.fee
+      this.transactionAmount = new Fee(fee.fee);
     });
   }
 

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.ts
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.ts
@@ -1,18 +1,22 @@
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 import { MatDialogRef } from '@angular/material';
 
+import { SendService } from '../send.service';
+
 import { Amount } from '../../../shared/util/utils';
+import { TransactionBuilder } from '../transaction-builder.model';
 
 @Component({
   selector: 'app-send-confirmation-modal',
   templateUrl: './send-confirmation-modal.component.html',
   styleUrls: ['./send-confirmation-modal.component.scss']
 })
-export class SendConfirmationModalComponent {
+export class SendConfirmationModalComponent implements OnInit {
 
   @Output() onConfirm: EventEmitter<string> = new EventEmitter<string>();
 
   public dialogContent: string;
+  public send: TransactionBuilder;
 
   // send-confirmation-modal variables
   transactionType: string = '';
@@ -22,7 +26,12 @@ export class SendConfirmationModalComponent {
   transactionFee: number = 0;
   totalAmount: number = 0;
 
-  constructor(private dialogRef: MatDialogRef<SendConfirmationModalComponent>) {
+  constructor(private dialogRef: MatDialogRef<SendConfirmationModalComponent>,
+              private sendService: SendService) {
+  }
+
+  ngOnInit() {
+    this.setDetails();
   }
 
   confirm(): void {
@@ -35,17 +44,22 @@ export class SendConfirmationModalComponent {
   }
 
   /**
-    * Set the modal details
-    * TODO: Create proper Interface for `send` parameter
+    * Set the confirmation modal data
     */
-  setDetails(send: any): void {
-    this.sendAddress = send.toAddress;
-    this.transactionType = send.input;
-    this.sendAmount = new Amount(send.amount);
-    this.receiverName = send.toLabel;
-    this.transactionFee = 0;
-    this.totalAmount = send.amount;
+  setDetails(): void {
+    this.getTransactionFee();
+
+    this.sendAddress = this.send.toAddress;
+    this.transactionType = this.send.input;
+    this.sendAmount = new Amount(this.send.amount);
+    this.receiverName = this.send.toLabel;
     console.log(this.transactionType);
+  }
+
+  getTransactionFee() {
+    this.sendService.getTransactionFee(this.send).subscribe(fee => {
+      this.transactionFee = fee.fee
+    });
   }
 
 }

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.ts
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.ts
@@ -46,7 +46,7 @@ export class SendConfirmationModalComponent {
     */
   setDetails(send: any): void {
     this.sendAddress = send.toAddress;
-    this.transactionType = this.addressHelper.getAddressType(this.sendAddress);
+    this.transactionType = send.input;
     this.sendAmount = new Amount(send.amount);
     this.receiverName = send.toLabel;
     this.transactionFee = 0;

--- a/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.ts
+++ b/src/app/wallet/wallet/send/send-confirmation-modal/send-confirmation-modal.component.ts
@@ -1,8 +1,6 @@
 import { Component, EventEmitter, Output } from '@angular/core';
 import { MatDialogRef } from '@angular/material';
 
-import { AddressHelper } from '../../../../wallet/shared/util/utils'
-
 import { Amount } from '../../../shared/util/utils';
 
 @Component({
@@ -16,9 +14,6 @@ export class SendConfirmationModalComponent {
 
   public dialogContent: string;
 
-  // components
-  private addressHelper: AddressHelper;
-
   // send-confirmation-modal variables
   transactionType: string = '';
   sendAmount: Amount;
@@ -27,8 +22,7 @@ export class SendConfirmationModalComponent {
   transactionFee: number = 0;
   totalAmount: number = 0;
 
-  constructor(private diloagRef: MatDialogRef<SendConfirmationModalComponent>) {
-    this.addressHelper = new AddressHelper();
+  constructor(private dialogRef: MatDialogRef<SendConfirmationModalComponent>) { 
   }
 
   confirm(): void {
@@ -37,7 +31,7 @@ export class SendConfirmationModalComponent {
   }
 
   dialogClose(): void {
-    this.diloagRef.close();
+    this.dialogRef.close();
   }
 
   /**

--- a/src/app/wallet/wallet/send/send.component.html
+++ b/src/app/wallet/wallet/send/send.component.html
@@ -24,23 +24,23 @@
 
       <!-- Select "FROM" balance/account -->
       <mat-radio-group class="from-balance-type block-radio" name="sendInput" [(ngModel)]="send.input" fxLayout="column" fxLayoutGap="10px" (change)="updateAmount()">
-        <mat-radio-button class="balance" value="balance" checked="checked" (click)="send.output = 'blind_balance'" fxFlex>
+        <mat-radio-button class="balance" value="part" checked="checked" (click)="send.output = 'blind'" fxFlex>
           <div class="name">Public</div>
-          <div class="desc">Available balance: <span class="amount">{{ getBalance('balance') }}</span></div>
+          <div class="desc">Available balance: <span class="amount">{{ getBalance('part') }}</span></div>
         </mat-radio-button>
-        <mat-radio-button class="balance" value="blind_balance" fxFlex (click)="send.output = 'balance'">
+        <mat-radio-button class="balance" value="blind" fxFlex (click)="send.output = 'part'">
           <div class="name">Blind</div>
-          <div class="desc">Available balance:<span *ngIf="!checkBalance('blind_balance')" class="amount">{{ getBalance('blind_balance') }}</span>
-          <mat-icon *ngIf="checkBalance('blind_balance')" fontSet="partIcon" fontIcon="part-circle-question" class="help-icon" matTooltip="It is normal to have a very small balance in Blind even after transferring out everything. This is due to the way CT works and part of the privacy platform."></mat-icon></div>
+          <div class="desc">Available balance:<span *ngIf="!checkBalance('blind')" class="amount">{{ getBalance('blind') }}</span>
+          <mat-icon *ngIf="checkBalance('blind')" fontSet="partIcon" fontIcon="part-circle-question" class="help-icon" matTooltip="It is normal to have a very small balance in Blind even after transferring out everything. This is due to the way CT works and part of the privacy platform."></mat-icon></div>
         </mat-radio-button>
-        <mat-radio-button *ngIf="testnet" class="balance" value="anon_balance" fxFlex>
+        <mat-radio-button *ngIf="testnet" class="balance" value="anon" fxFlex>
           <div class="name">Anon</div>
-          <div class="desc">Available balance:<span class="amount">{{ getBalance('anon_balance') }}</span></div>
+          <div class="desc">Available balance:<span class="amount">{{ getBalance('anon') }}</span></div>
         </mat-radio-button>
       </mat-radio-group><!-- .from-balance-type -->
 
       <!-- Show privacy slider if anonymous TX -->
-      <div *ngIf="send.input === 'anon_balance'">
+      <div *ngIf="send.input === 'anon'">
         <div class="subtitle">Select privacy level</div>
         <div class="privacy-level">
           <div class="privacy-labels" fxLayout="row" fxLayoutAlign="space-between center">
@@ -57,14 +57,14 @@
       </div><!-- /if Anon -->
 
       <!-- TX info help -->
-      <p class="widget-help" *ngIf="send.input === 'balance'">
+      <p class="widget-help" *ngIf="send.input === 'part'">
         In public transactions, everything is visible on the blockchain &ndash; transaction amount, sender and receiver
         addresses.
       </p>
-      <p class="widget-help" *ngIf="send.input === 'blind_balance'">
+      <p class="widget-help" *ngIf="send.input === 'blind'">
         Blinded transactions hide transaction amounts, but the sender and receiver addresses are still visible.
       </p>
-      <p class="widget-help" *ngIf="send.input === 'anon_balance'">
+      <p class="widget-help" *ngIf="send.input === 'anon'">
         Anon transaction offer the highest privacy &ndash; transaction amounts and not even sender and receiver
         addresses are publicly visible. You can further adjust the privacy level to your needs ("Normal" privacy level
         is fine for most users). The higher privacy level is, the larger fee needs to be paid.
@@ -92,19 +92,19 @@
           </button>
         </div>
         <mat-radio-group class="to-balance-type block-radio" name="sendOutput" [(ngModel)]="send.output" fxLayout="column" fxLayoutGap="10px" (change)="updateAmount()">
-          <mat-radio-button class="balance" value="balance" (click)="send.input = 'blind_balance'" checked="checked" fxFlex>
+          <mat-radio-button class="balance" value="part" (click)="send.input = 'blind'" checked="checked" fxFlex>
             <div class="name">Public</div>
-            <div class="desc">Balance:<span class="amount">{{ getBalance('balance') }}</span></div>
+            <div class="desc">Balance:<span class="amount">{{ getBalance('part') }}</span></div>
           </mat-radio-button>
-          <mat-radio-button class="balance" value="blind_balance" (click)="send.input = 'balance'" fxFlex>
+          <mat-radio-button class="balance" value="blind" (click)="send.input = 'part'" fxFlex>
             <div class="name">Blind</div>
-            <div class="desc">Balance:<span *ngIf="!checkBalance('blind_balance')" class="amount">{{ getBalance('blind_balance') }}</span>
-              <mat-icon *ngIf="checkBalance('blind_balance')" fontSet="partIcon" fontIcon="part-circle-question" class="help-icon" matTooltip="It is normal to have a very small balance in Blind even after transferring out everything. This is due to the way CT works and part of the privacy platform."></mat-icon>
+            <div class="desc">Balance:<span *ngIf="!checkBalance('blind')" class="amount">{{ getBalance('blind') }}</span>
+              <mat-icon *ngIf="checkBalance('blind')" fontSet="partIcon" fontIcon="part-circle-question" class="help-icon" matTooltip="It is normal to have a very small balance in Blind even after transferring out everything. This is due to the way CT works and part of the privacy platform."></mat-icon>
             </div>
           </mat-radio-button>
-          <mat-radio-button *ngIf="testnet" class="balance" value="anon_balance" fxFlex>
+          <mat-radio-button *ngIf="testnet" class="balance" value="anon" fxFlex>
             <div class="name">Anon</div>
-            <div class="desc">Balance:<span class="amount">{{ getBalance('anon_balance') }}</span></div>
+            <div class="desc">Balance:<span class="amount">{{ getBalance('anon') }}</span></div>
           </mat-radio-button>
         </mat-radio-group><!-- .from-balance-type -->
         <p class="widget-help">

--- a/src/app/wallet/wallet/send/send.component.html
+++ b/src/app/wallet/wallet/send/send.component.html
@@ -31,7 +31,7 @@
           <div class="desc">Available balance: <span class="amount">{{ getBalance('part') }}</span></div>
         </mat-radio-button>
         <mat-radio-button class="balance" value="blind" fxFlex (click)="send.output = 'part'">
-          <div class="name">Blind 1</div>
+          <div class="name">Blind</div>
           <div class="desc">Available balance:<span *ngIf="!checkBalance('blind')" class="amount">{{ getBalance('blind') }}</span>
             <mat-icon *ngIf="checkBalance('blind')" fontSet="partIcon" fontIcon="part-circle-question" class="help-icon"
                       matTooltip="It is normal to have a very small balance in Blind even after transferring out everything. This is due to the way CT works and part of the privacy platform."></mat-icon>

--- a/src/app/wallet/wallet/send/send.component.html
+++ b/src/app/wallet/wallet/send/send.component.html
@@ -25,12 +25,13 @@
       <!-- Select "FROM" balance/account -->
       <mat-radio-group class="from-balance-type block-radio" name="sendInput" [(ngModel)]="send.input" fxLayout="column"
                        fxLayoutGap="10px" (change)="updateAmount()">
-        <mat-radio-button class="balance" value="part" checked="checked" (click)="send.output = 'blind'" fxFlex>
+        <mat-radio-button class="balance" value="part" checked="checked"
+                          (click)="send.output = (type === 'sendPayment')? 'part': 'blind'" fxFlex>
           <div class="name">Public</div>
           <div class="desc">Available balance: <span class="amount">{{ getBalance('part') }}</span></div>
         </mat-radio-button>
         <mat-radio-button class="balance" value="blind" fxFlex (click)="send.output = 'part'">
-          <div class="name">Blind</div>
+          <div class="name">Blind 1</div>
           <div class="desc">Available balance:<span *ngIf="!checkBalance('blind')" class="amount">{{ getBalance('blind') }}</span>
             <mat-icon *ngIf="checkBalance('blind')" fontSet="partIcon" fontIcon="part-circle-question" class="help-icon"
                       matTooltip="It is normal to have a very small balance in Blind even after transferring out everything. This is due to the way CT works and part of the privacy platform."></mat-icon>

--- a/src/app/wallet/wallet/send/send.component.html
+++ b/src/app/wallet/wallet/send/send.component.html
@@ -30,7 +30,7 @@
         </mat-radio-button>
         <mat-radio-button class="balance" value="blind_balance" fxFlex (click)="send.output = 'balance'">
           <div class="name">Blind</div>
-          <div class="desc">Available balance:<span *ngIf="!checkBalance('blind_balance')" class="amount">{{ getBalance('blind_balance') }}</span> 
+          <div class="desc">Available balance:<span *ngIf="!checkBalance('blind_balance')" class="amount">{{ getBalance('blind_balance') }}</span>
           <mat-icon *ngIf="checkBalance('blind_balance')" fontSet="partIcon" fontIcon="part-circle-question" class="help-icon" matTooltip="It is normal to have a very small balance in Blind even after transferring out everything. This is due to the way CT works and part of the privacy platform."></mat-icon></div>
         </mat-radio-button>
         <mat-radio-button *ngIf="testnet" class="balance" value="anon_balance" fxFlex>
@@ -51,7 +51,7 @@
             <span fxFlex="0 0 50px" class="privacy-label high" (click)="setPrivacy(16,100)" matTooltip="High privacy"
                   matTooltipPosition="below">High</span>
           </div><!-- .privacy-labels -->
-          <mat-progress-bar [color]="'primary'" [bufferValue]="send.privacy" [mode]="'determinate'"
+          <mat-progress-bar [color]="'primary'" [bufferValue]="send.ringsize" [mode]="'determinate'"
                             [value]="progress"></mat-progress-bar>
         </div><!-- .privacy-level -->
       </div><!-- /if Anon -->

--- a/src/app/wallet/wallet/send/send.component.html
+++ b/src/app/wallet/wallet/send/send.component.html
@@ -156,7 +156,7 @@
         <div class="section narration advanced" *ngIf="advanced">
           <mat-form-field class="full-width larger" floatPlaceholder="never">
             <input #narration type="text" matInput name="sendNote" placeholder="Narration (optional)" maxlength="24"
-                   [(ngModel)]="send.note">
+                   [(ngModel)]="send.narration">
             <mat-hint align="end">{{narration.value.length}} / 24</mat-hint>
           </mat-form-field>
           <p class="widget-help">

--- a/src/app/wallet/wallet/send/send.component.html
+++ b/src/app/wallet/wallet/send/send.component.html
@@ -23,7 +23,8 @@
       <div class="title">Pay from</div>
 
       <!-- Select "FROM" balance/account -->
-      <mat-radio-group class="from-balance-type block-radio" name="sendInput" [(ngModel)]="send.input" fxLayout="column" fxLayoutGap="10px" (change)="updateAmount()">
+      <mat-radio-group class="from-balance-type block-radio" name="sendInput" [(ngModel)]="send.input" fxLayout="column"
+                       fxLayoutGap="10px" (change)="updateAmount()">
         <mat-radio-button class="balance" value="part" checked="checked" (click)="send.output = 'blind'" fxFlex>
           <div class="name">Public</div>
           <div class="desc">Available balance: <span class="amount">{{ getBalance('part') }}</span></div>
@@ -31,9 +32,11 @@
         <mat-radio-button class="balance" value="blind" fxFlex (click)="send.output = 'part'">
           <div class="name">Blind</div>
           <div class="desc">Available balance:<span *ngIf="!checkBalance('blind')" class="amount">{{ getBalance('blind') }}</span>
-          <mat-icon *ngIf="checkBalance('blind')" fontSet="partIcon" fontIcon="part-circle-question" class="help-icon" matTooltip="It is normal to have a very small balance in Blind even after transferring out everything. This is due to the way CT works and part of the privacy platform."></mat-icon></div>
+            <mat-icon *ngIf="checkBalance('blind')" fontSet="partIcon" fontIcon="part-circle-question" class="help-icon"
+                      matTooltip="It is normal to have a very small balance in Blind even after transferring out everything. This is due to the way CT works and part of the privacy platform."></mat-icon>
+          </div>
         </mat-radio-button>
-        <mat-radio-button *ngIf="testnet" class="balance" value="anon" fxFlex>
+        <mat-radio-button *ngIf="testnet" class="balance" value="anon" (click)="send.output = 'part'" fxFlex>
           <div class="name">Anon</div>
           <div class="desc">Available balance:<span class="amount">{{ getBalance('anon') }}</span></div>
         </mat-radio-button>
@@ -91,18 +94,22 @@
             <span>Advanced options</span>
           </button>
         </div>
-        <mat-radio-group class="to-balance-type block-radio" name="sendOutput" [(ngModel)]="send.output" fxLayout="column" fxLayoutGap="10px" (change)="updateAmount()">
+        <mat-radio-group class="to-balance-type block-radio" name="sendOutput" [(ngModel)]="send.output"
+                         fxLayout="column" fxLayoutGap="10px" (change)="updateAmount()">
           <mat-radio-button class="balance" value="part" (click)="send.input = 'blind'" checked="checked" fxFlex>
             <div class="name">Public</div>
             <div class="desc">Balance:<span class="amount">{{ getBalance('part') }}</span></div>
           </mat-radio-button>
           <mat-radio-button class="balance" value="blind" (click)="send.input = 'part'" fxFlex>
             <div class="name">Blind</div>
-            <div class="desc">Balance:<span *ngIf="!checkBalance('blind')" class="amount">{{ getBalance('blind') }}</span>
-              <mat-icon *ngIf="checkBalance('blind')" fontSet="partIcon" fontIcon="part-circle-question" class="help-icon" matTooltip="It is normal to have a very small balance in Blind even after transferring out everything. This is due to the way CT works and part of the privacy platform."></mat-icon>
+            <div class="desc">Balance:<span *ngIf="!checkBalance('blind')"
+                                            class="amount">{{ getBalance('blind') }}</span>
+              <mat-icon *ngIf="checkBalance('blind')" fontSet="partIcon" fontIcon="part-circle-question"
+                        class="help-icon"
+                        matTooltip="It is normal to have a very small balance in Blind even after transferring out everything. This is due to the way CT works and part of the privacy platform."></mat-icon>
             </div>
           </mat-radio-button>
-          <mat-radio-button *ngIf="testnet" class="balance" value="anon" fxFlex>
+          <mat-radio-button *ngIf="testnet" class="balance" value="anon" (click)="send.input = 'part'" fxFlex>
             <div class="name">Anon</div>
             <div class="desc">Balance:<span class="amount">{{ getBalance('anon') }}</span></div>
           </mat-radio-button>
@@ -115,7 +122,8 @@
       <mat-card class="pay-to" *ngIf="type === 'sendPayment' || advanced">
         <div class="title">
           Pay to
-          <button mat-button (click)="advanced = !advanced" *ngIf="type === 'sendPayment'" class="small advanced-options">
+          <button mat-button (click)="advanced = !advanced" *ngIf="type === 'sendPayment'"
+                  class="small advanced-options">
             <mat-icon fontSet="partIcon"
                       fontIcon="{{ (advanced) ? 'part-circle-minus': 'part-circle-plus' }}"></mat-icon>
             <span>Advanced options</span>
@@ -145,7 +153,8 @@
             </span>
           </div>
           <mat-form-field class="full-width larger no-top-padding" floatPlaceholder="never">
-            <input name="toLabel" matInput type="text" placeholder="Receiver's name (optional)" [(ngModel)]="send.toLabel">
+            <input name="toLabel" matInput type="text" placeholder="Receiver's name (optional)"
+                   [(ngModel)]="send.toLabel">
           </mat-form-field>
           <p class="widget-help">
             You can save Receiver's address to your Address book by labeling it here.
@@ -176,7 +185,8 @@
                  [ngClass]="{'verify-sucess': checkAmount() === true, 'verify-error': checkAmount() === false }"
                  [disabled]="send.subtractFeeFromAmount">
         </mat-form-field>
-        <mat-checkbox name="send_all" [(ngModel)]="send.subtractFeeFromAmount" (click)="sendAllBalance()" class="send-all">
+        <mat-checkbox name="send_all" [(ngModel)]="send.subtractFeeFromAmount" (click)="sendAllBalance()"
+                      class="send-all">
           Send All
         </mat-checkbox>
         <!-- Choose currency -->

--- a/src/app/wallet/wallet/send/send.component.spec.ts
+++ b/src/app/wallet/wallet/send/send.component.spec.ts
@@ -7,13 +7,12 @@ import { CoreUiModule } from '../../../core-ui/core-ui.module';
 import { ModalsModule } from '../../../modals/modals.module';
 
 import { SharedModule } from '../../shared/shared.module'; // is this even needed?
-import { WalletModule } from '../wallet.module';
 
 
 import { SendComponent } from './send.component';
 import { SendService } from 'app/wallet/wallet/send/send.service';
 
-import { RpcService, RpcStateService } from '../../../core/core.module';
+import { RpcService } from '../../../core/core.module';
 import { RpcMockService } from '../../../_test/core-test/rpc-test/rpc-mock.service';
 
 describe('SendComponent', () => {

--- a/src/app/wallet/wallet/send/send.component.ts
+++ b/src/app/wallet/wallet/send/send.component.ts
@@ -179,11 +179,7 @@ export class SendComponent implements OnInit {
     const d = this.dialog.open(SendConfirmationModalComponent);
     const dc = d.componentInstance;
 
-    let txt = `Do you really want to send ${this.send.amount} ${this.send.currency.toUpperCase()} to ${this.send.toAddress}?`
-    if (this.type === 'balanceTransfer') {
-      txt = `Do you really want to transfer the following balance ${this.send.amount} ${this.send.currency.toUpperCase()}?`
-    }
-    dc.dialogContent = txt;
+    dc.setDetails(this.send);
 
     dc.onConfirm.subscribe(() => {
       d.close();

--- a/src/app/wallet/wallet/send/send.component.ts
+++ b/src/app/wallet/wallet/send/send.component.ts
@@ -13,7 +13,10 @@ import { SnackbarService } from '../../../core/snackbar/snackbar.service';
 import { AddressLookupComponent } from '../addresslookup/addresslookup.component';
 import { AddressLookUpCopy } from '../models/address-look-up-copy';
 import { SendConfirmationModalComponent } from './send-confirmation-modal/send-confirmation-modal.component';
+
 import { AddressHelper } from '../../../core/util/utils';
+import { TransactionBuilder } from './transaction-builder.model';
+
 
 @Component({
   selector: 'app-send',
@@ -34,18 +37,7 @@ export class SendComponent implements OnInit {
   advanced: boolean = false;
   progress: number = 10;
   // TODO: Create proper Interface / type
-  send: any = {
-    input: 'balance',
-    output: 'blind_balance',
-    toAddress: '',
-    toLabel: '',
-    validAddress: undefined,
-    validAmount: undefined,
-    isMine: undefined,
-    currency: 'part',
-    privacy: 8,
-    subtractFeeFromAmount: false
-  };
+  public send: TransactionBuilder;
 
   constructor(
     private sendService: SendService,
@@ -57,6 +49,19 @@ export class SendComponent implements OnInit {
   ) {
     this.progress = 50;
     this.addressHelper = new AddressHelper();
+
+    this.setFormDefaultValue();
+  }
+
+  setFormDefaultValue() {
+    this.send = new TransactionBuilder();
+
+    this.send.input = 'balance';
+    this.send.output = 'blind_balance';
+    this.send.currency = 'part';
+    this.send.privacy = 8;
+    this.send.subtractFeeFromAmount = false;
+    this.send.numsignatures = 1;
   }
 
   ngOnInit() {
@@ -70,7 +75,7 @@ export class SendComponent implements OnInit {
     this.send.input = 'balance';
     if (this.type === 'balanceTransfer') {
       this.send.toAddress = '';
-      this.send.output = 'blind_balance'
+      this.send.output = 'blind_balance';
       this.verifyAddress();
     }
     this.updateAmount();
@@ -237,18 +242,12 @@ export class SendComponent implements OnInit {
       // edit label of address
       this.addLabelToAddress();
 
-      this.sendService.sendTransaction(
-        this.send.input, this.send.output,
-        this.send.toAddress, this.send.amount,
-        this.send.note, this.send.note,
-        this.send.privacy, 1, this.send.subtractFeeFromAmount);
+      this.sendService.sendTransaction(this.send);
     } else {
 
-      this.sendService.transferBalance(
-        this.send.input, this.send.output,
-        this.send.amount, this.send.privacy, 1, this.send.subtractFeeFromAmount);
+      this.sendService.transferBalance(this.send);
     }
-    this.clear();
+    this.setFormDefaultValue();
   }
   /*
     AddressLookup Modal + set details

--- a/src/app/wallet/wallet/send/send.component.ts
+++ b/src/app/wallet/wallet/send/send.component.ts
@@ -59,7 +59,7 @@ export class SendComponent implements OnInit {
     this.send.input = 'balance';
     this.send.output = 'blind_balance';
     this.send.currency = 'part';
-    this.send.privacy = 8;
+    this.send.ringsize = 8;
     this.send.subtractFeeFromAmount = false;
     this.send.numsignatures = 1;
   }
@@ -302,7 +302,7 @@ export class SendComponent implements OnInit {
   }
 
   setPrivacy(level: number, prog: number): void {
-    this.send.privacy = level;
+    this.send.ringsize = level;
     this.progress = prog;
   }
 

--- a/src/app/wallet/wallet/send/send.component.ts
+++ b/src/app/wallet/wallet/send/send.component.ts
@@ -55,13 +55,6 @@ export class SendComponent implements OnInit {
 
   setFormDefaultValue() {
     this.send = new TransactionBuilder();
-
-    this.send.input = 'balance';
-    this.send.output = 'blind_balance';
-    this.send.currency = 'part';
-    this.send.ringsize = 8;
-    this.send.subtractFeeFromAmount = false;
-    this.send.numsignatures = 1;
   }
 
   ngOnInit() {

--- a/src/app/wallet/wallet/send/send.component.ts
+++ b/src/app/wallet/wallet/send/send.component.ts
@@ -66,6 +66,7 @@ export class SendComponent implements OnInit {
   selectTab(tabIndex: number): void {
     this.type = (tabIndex) ? 'balanceTransfer' : 'sendPayment';
     this.send.input = TxType.PUBLIC;
+    this.send.output = TxType.PUBLIC;
     if (this.type === 'balanceTransfer') {
       this.send.toAddress = '';
       this.send.output = TxType.BLIND;

--- a/src/app/wallet/wallet/send/send.component.ts
+++ b/src/app/wallet/wallet/send/send.component.ts
@@ -161,19 +161,6 @@ export class SendComponent implements OnInit {
         error => this.log.er('verifyAddress: validateAddressCB failed'));
   }
 
-  /** Clear the send object. */
-  clear(): void {
-    this.send = {
-      input: this.send.input,
-      output: this.send.output,
-      validAddress: undefined,
-      validAmount: undefined,
-      currency: 'part',
-      privacy: 50
-    };
-    this.send.subtractFeeFromAmount = false;
-  }
-
   clearReceiver(): void {
     this.send.toLabel = '';
     this.send.toAddress = '';

--- a/src/app/wallet/wallet/send/send.component.ts
+++ b/src/app/wallet/wallet/send/send.component.ts
@@ -168,29 +168,12 @@ export class SendComponent implements OnInit {
   }
 
   onSubmit(): void {
-    // @TODO refactor unlock wallet checking
-    // this.checkWalletIslocked(this.openSendConfirmationModal, 30);
     if (this._rpcState.get('locked')) {
       // unlock wallet and send transaction
       this._modals.open('unlock', {forceOpen: true, timeout: 30, callback: this.openSendConfirmationModal.bind(this)});
     } else {
       // wallet already unlocked
       this.openSendConfirmationModal();
-    }
-  }
-
-  /**
-    * Check wallet is locked
-    * @param callback
-    */
-
-  checkWalletIslocked(callback: any, timeout: number = 10) {
-    if (this._rpcState.get('locked')) {
-      // unlock wallet and send transaction
-      this._modals.open('unlock', {forceOpen: true, timeout: 10, callback: callback.bind(this)});
-    } else {
-      // wallet already unlocked
-      callback();
     }
   }
 
@@ -248,7 +231,13 @@ export class SendComponent implements OnInit {
 
     }
 
-    this.checkWalletIslocked(this.sendTransaction);
+    if (this._rpcState.get('locked')) {
+      // unlock wallet and send transaction
+      this._modals.open('unlock', {forceOpen: true, timeout: 30, callback: this.sendTransaction.bind(this)});
+    } else {
+      // wallet already unlocked
+      this.sendTransaction();
+    }
   }
 
   private sendTransaction(): void {

--- a/src/app/wallet/wallet/send/send.service.ts
+++ b/src/app/wallet/wallet/send/send.service.ts
@@ -43,18 +43,29 @@ export class SendService {
         error => this.rpc_send_failed(error.message, tx.toAddress, tx.amount));
   }
 
-  // @TODO refactor this method for balance transfer without address
   public getTransactionFee(tx: TransactionBuilder): Observable<any> {
-    // this.getDefaultStealthAddress().take(1).subscribe(
-    //   (stealthAddress: string) => {
-    //
-    //   });
-    return this._rpc.call('sendtypeto', ['part', 'part', [{
-      subfee: true,
-      address: tx.toAddress,
-      amount: tx.amount,
-    }], '', '', 8, 64, true]).map(
-      fee => fee);
+    if (!tx.toAddress) {
+      return new Observable((observer) => {
+        this.getDefaultStealthAddress().take(1).subscribe(
+          (stealthAddress: string) => {
+            this._rpc.call('sendtypeto', ['part', 'part', [{
+              subfee: true,
+              address: stealthAddress,
+              amount: tx.amount,
+            }], '', '', 8, 64, true]).subscribe(fee => {
+              observer.next(fee);
+              observer.complete(fee);
+            });
+          });
+      });
+    } else {
+      return this._rpc.call('sendtypeto', ['part', 'part', [{
+        subfee: true,
+        address: tx.toAddress,
+        amount: tx.amount,
+      }], '', '', 8, 64, true]).map(
+        fee => fee);
+    }
   }
 
   public transferBalance(tx: TransactionBuilder) {

--- a/src/app/wallet/wallet/send/send.service.ts
+++ b/src/app/wallet/wallet/send/send.service.ts
@@ -35,7 +35,7 @@ export class SendService {
     const anon: boolean = this.isAnon(rpcCall);
     const params: Array<any> = this.getSendParams(
       anon, tx.toAddress, tx.amount, tx.comment,
-      tx.narration, tx.privacy, tx.numsignatures, tx.subtractFeeFromAmount);
+      tx.narration, tx.ringsize, tx.numsignatures, tx.subtractFeeFromAmount);
 
     this._rpc.call('send' + rpcCall, params)
       .subscribe(
@@ -80,7 +80,7 @@ export class SendService {
         const anon: boolean = this.isAnon(rpcCall);
         const params: Array<any> = this.getSendParams(
           anon, stealthAddress,
-          tx.amount, '', '', tx.privacy, tx.numsignatures, tx.subtractFeeFromAmount);
+          tx.amount, '', '', tx.ringsize, tx.numsignatures, tx.subtractFeeFromAmount);
 
         this._rpc.call('send' + rpcCall, params).subscribe(
           success => this.rpc_send_success(success, stealthAddress, tx.amount),

--- a/src/app/wallet/wallet/send/send.service.ts
+++ b/src/app/wallet/wallet/send/send.service.ts
@@ -35,8 +35,8 @@ export class SendService {
     const anon: boolean = this.isAnon(rpcCall);
     const params: Array<any> = this.getSendParams(
       anon, tx.toAddress, tx.amount, tx.comment,
-      tx.narration, tx.ringsize, tx.numsignatures, tx.subtractFeeFromAmount);
-
+      tx.narration, +tx.ringsize, tx.numsignatures, tx.subtractFeeFromAmount);
+      console.log(params);
     this._rpc.call('send' + rpcCall, params)
       .subscribe(
         success => this.rpc_send_success(success, tx.toAddress, tx.amount),
@@ -48,7 +48,7 @@ export class SendService {
       return new Observable((observer) => {
         this.getDefaultStealthAddress().take(1).subscribe(
           (stealthAddress: string) => {
-            this._rpc.call('sendtypeto', ['part', 'part', [{
+            this._rpc.call('sendtypeto', [tx.input, tx.output, [{
               subfee: true,
               address: stealthAddress,
               amount: tx.amount,
@@ -59,7 +59,7 @@ export class SendService {
           });
       });
     } else {
-      return this._rpc.call('sendtypeto', ['part', 'part', [{
+      return this._rpc.call('sendtypeto', [tx.input, tx.output, [{
         subfee: true,
         address: tx.toAddress,
         amount: tx.amount,
@@ -80,7 +80,7 @@ export class SendService {
         const anon: boolean = this.isAnon(rpcCall);
         const params: Array<any> = this.getSendParams(
           anon, stealthAddress,
-          tx.amount, '', '', tx.ringsize, tx.numsignatures, tx.subtractFeeFromAmount);
+          tx.amount, '', '', +tx.ringsize, tx.numsignatures, tx.subtractFeeFromAmount);
 
         this._rpc.call('send' + rpcCall, params).subscribe(
           success => this.rpc_send_success(success, stealthAddress, tx.amount),
@@ -160,13 +160,13 @@ export class SendService {
     anon: boolean, address: string, amount: number, comment: string,
     narration: string, ringsize: number, numsignatures: number, substractfeefromamount: boolean) {
 
-    const params: Array<any> = [address, amount, '', '', substractfeefromamount];
+    const params: Array<any> = [address, +amount, '', '', substractfeefromamount];
 
     params.push(!!narration ? narration : '');
 
     if (anon) {
       // comment-to empty
-      params.push(this.getRingSize(ringsize));
+      params.push(+ringsize);
       // params.push(numsignatures);
     }
 
@@ -180,16 +180,4 @@ export class SendService {
     return ['anontopart', 'anontoanon', 'anontoblind'].includes(input)
   }
 
-  /**
-  * Converts slider logic (0 -> 100) to actual ring size for RPC parameters.
-  */
-  getRingSize(ringsize: number): number {
-    if (ringsize === 100) {
-      return 16;
-    } else if (ringsize === 50) {
-      return 8;
-    } else if (ringsize === 10) {
-      return 4;
-    }
-  }
 }

--- a/src/app/wallet/wallet/send/send.service.ts
+++ b/src/app/wallet/wallet/send/send.service.ts
@@ -52,7 +52,7 @@ export class SendService {
               subfee: true,
               address: stealthAddress,
               amount: tx.amount,
-            }], '', '', 8, 64, true]).subscribe(fee => {
+            }], '', '', tx.ringsize, 64, true]).subscribe(fee => {
               observer.next(fee);
               observer.complete();
             });
@@ -63,7 +63,7 @@ export class SendService {
         subfee: true,
         address: tx.toAddress,
         amount: tx.amount,
-      }], '', '', 8, 64, true]).map(
+      }], '', '', tx.ringsize, 64, true]).map(
         fee => fee);
     }
   }
@@ -145,8 +145,6 @@ export class SendService {
     */
   getSendRPCCall(input: string, output: string) {
 
-    input = input.replace('_balance', '').replace('balance', 'part');
-    output = output.replace('_balance', '').replace('balance', 'part');
     if (input === 'part' && output === 'part') {
       return 'toaddress';
     } else {

--- a/src/app/wallet/wallet/send/send.service.ts
+++ b/src/app/wallet/wallet/send/send.service.ts
@@ -8,7 +8,7 @@ import { SnackbarService } from '../../../core/snackbar/snackbar.service';
 /* fix wallet */
 import { MatDialog } from '@angular/material';
 import { FixWalletModalComponent } from 'app/wallet/wallet/send/fix-wallet-modal/fix-wallet-modal.component';
-import {TransactionBuilder} from "./transaction-builder.model";
+import {TransactionBuilder} from './transaction-builder.model';
 
 /*
   Note: due to upcoming multiwallet, we should never ever store addresses in the GUI for transaction purposes.

--- a/src/app/wallet/wallet/send/send.service.ts
+++ b/src/app/wallet/wallet/send/send.service.ts
@@ -28,7 +28,6 @@ export class SendService {
 
   /* Sends a transaction */
   public sendTransaction(tx: TransactionBuilder) {
-    tx.comment = null;
     tx.estimateFeeOnly = false;
 
     this.send(tx)
@@ -94,7 +93,7 @@ export class SendService {
       amount: tx.amount,
       subfee: tx.subtractFeeFromAmount,
       narr: tx.narration
-    }], '', '', tx.ringsize, 64, tx.estimateFeeOnly]);
+    }], tx.comment, tx.commentTo, tx.ringsize, 64, tx.estimateFeeOnly]);
   }
 
   private rpc_send_success(json: any, address: string, amount: number) {

--- a/src/app/wallet/wallet/send/send.service.ts
+++ b/src/app/wallet/wallet/send/send.service.ts
@@ -8,7 +8,7 @@ import { SnackbarService } from '../../../core/snackbar/snackbar.service';
 /* fix wallet */
 import { MatDialog } from '@angular/material';
 import { FixWalletModalComponent } from 'app/wallet/wallet/send/fix-wallet-modal/fix-wallet-modal.component';
-import {TransactionBuilder} from './transaction-builder.model';
+import { TransactionBuilder } from './transaction-builder.model';
 
 /*
   Note: due to upcoming multiwallet, we should never ever store addresses in the GUI for transaction purposes.
@@ -28,7 +28,7 @@ export class SendService {
 
   /* Sends a transaction */
   // @TODO: estimate fee should be change
-  public sendTransaction(tx: TransactionBuilder, estimateFee: boolean = true) {
+  public sendTransaction(tx: TransactionBuilder) {
     tx.comment = tx.narration = tx.note;
 
     const rpcCall: string = this.getSendRPCCall(tx.input, tx.output);
@@ -36,10 +36,25 @@ export class SendService {
     const params: Array<any> = this.getSendParams(
       anon, tx.toAddress, tx.amount, tx.comment,
       tx.narration, tx.privacy, tx.numsignatures, tx.subtractFeeFromAmount);
+
     this._rpc.call('send' + rpcCall, params)
       .subscribe(
-      success => this.rpc_send_success(success, tx.toAddress, tx.amount),
-      error => this.rpc_send_failed(error.message, tx.toAddress, tx.amount));
+        success => this.rpc_send_success(success, tx.toAddress, tx.amount),
+        error => this.rpc_send_failed(error.message, tx.toAddress, tx.amount));
+  }
+
+  // @TODO refactor this method for balance transfer without address
+  public getTransactionFee(tx: TransactionBuilder): Observable<any> {
+    // this.getDefaultStealthAddress().take(1).subscribe(
+    //   (stealthAddress: string) => {
+    //
+    //   });
+    return this._rpc.call('sendtypeto', ['part', 'part', [{
+      subfee: true,
+      address: tx.toAddress,
+      amount: tx.amount,
+    }], '', '', 8, 64, true]).map(
+      fee => fee);
   }
 
   public transferBalance(tx: TransactionBuilder) {

--- a/src/app/wallet/wallet/send/send.service.ts
+++ b/src/app/wallet/wallet/send/send.service.ts
@@ -29,7 +29,7 @@ export class SendService {
   /* Sends a transaction */
   // @TODO: estimate fee should be change
   public sendTransaction(tx: TransactionBuilder) {
-    tx.comment = tx.narration = tx.note;
+    tx.comment = null;
 
     const rpcCall: string = this.getSendRPCCall(tx.input, tx.output);
     const anon: boolean = this.isAnon(rpcCall);

--- a/src/app/wallet/wallet/send/send.service.ts
+++ b/src/app/wallet/wallet/send/send.service.ts
@@ -54,7 +54,7 @@ export class SendService {
               amount: tx.amount,
             }], '', '', 8, 64, true]).subscribe(fee => {
               observer.next(fee);
-              observer.complete(fee);
+              observer.complete();
             });
           });
       });

--- a/src/app/wallet/wallet/send/transaction-builder.model.ts
+++ b/src/app/wallet/wallet/send/transaction-builder.model.ts
@@ -26,7 +26,7 @@ export class TransactionBuilder {
   constructor() {
     // set default value
     this.input = TxType.PUBLIC;
-    this.output = TxType.BLIND;
+    this.output = TxType.PUBLIC; // set it public for default send payment tab.
     this.currency = 'part';
     this.ringsize = 8;
     this.subtractFeeFromAmount = false;

--- a/src/app/wallet/wallet/send/transaction-builder.model.ts
+++ b/src/app/wallet/wallet/send/transaction-builder.model.ts
@@ -5,29 +5,24 @@ export enum TxType {
 }
 
 export class TransactionBuilder {
-  input: TxType;
-  output: TxType;
+  input: TxType = TxType.PUBLIC;
+  output: TxType = TxType.PUBLIC;
   toAddress: string;
   toLabel: string;
   address: string;
   amount: number;
   comment: string;
   narration: string;
-  numsignatures: number;
+  numsignatures: number = 1;
   validAddress: boolean;
   validAmount: boolean;
   isMine: boolean;
-  currency: string;
-  ringsize: number;
-  subtractFeeFromAmount: boolean;
+  currency: string = 'part';
+  ringsize: number = 8;
+  subtractFeeFromAmount: boolean = false;
+  estimateFeeOnly: boolean = true;
 
   constructor() {
-    // set default value
-    this.input = TxType.PUBLIC;
-    this.output = TxType.PUBLIC; // set it public for default send payment tab.
-    this.currency = 'part';
-    this.ringsize = 8;
-    this.subtractFeeFromAmount = false;
-    this.numsignatures = 1;
+
   }
 }

--- a/src/app/wallet/wallet/send/transaction-builder.model.ts
+++ b/src/app/wallet/wallet/send/transaction-builder.model.ts
@@ -16,4 +16,14 @@ export class TransactionBuilder {
   subtractFeeFromAmount: boolean;
   note: string;
   transactionFee: number;
+
+  constructor() {
+    // set default value
+    this.input = 'balance';
+    this.output = 'blind_balance';
+    this.currency = 'part';
+    this.ringsize = 8;
+    this.subtractFeeFromAmount = false;
+    this.numsignatures = 1;
+  }
 }

--- a/src/app/wallet/wallet/send/transaction-builder.model.ts
+++ b/src/app/wallet/wallet/send/transaction-builder.model.ts
@@ -1,6 +1,12 @@
+export enum TxType {
+  PUBLIC = 'part',
+  BLIND = 'blind',
+  ANON = 'anon'
+}
+
 export class TransactionBuilder {
-  input: string;
-  output: string;
+  input: TxType;
+  output: TxType;
   toAddress: string;
   toLabel: string;
   address: string;
@@ -19,8 +25,8 @@ export class TransactionBuilder {
 
   constructor() {
     // set default value
-    this.input = 'balance';
-    this.output = 'blind_balance';
+    this.input = TxType.PUBLIC;
+    this.output = TxType.BLIND;
     this.currency = 'part';
     this.ringsize = 8;
     this.subtractFeeFromAmount = false;

--- a/src/app/wallet/wallet/send/transaction-builder.model.ts
+++ b/src/app/wallet/wallet/send/transaction-builder.model.ts
@@ -1,0 +1,18 @@
+export class TransactionBuilder {
+  input: string;
+  output: string;
+  toAddress: string;
+  toLabel: string;
+  address: string;
+  amount: number;
+  comment: string;
+  narration: string;
+  numsignatures: number;
+  validAddress: boolean;
+  validAmount: boolean;
+  isMine: boolean;
+  currency: string;
+  privacy: number;
+  subtractFeeFromAmount: boolean;
+  note: string;
+}

--- a/src/app/wallet/wallet/send/transaction-builder.model.ts
+++ b/src/app/wallet/wallet/send/transaction-builder.model.ts
@@ -12,7 +12,7 @@ export class TransactionBuilder {
   validAmount: boolean;
   isMine: boolean;
   currency: string;
-  privacy: number;
+  ringsize: number;
   subtractFeeFromAmount: boolean;
   note: string;
   transactionFee: number;

--- a/src/app/wallet/wallet/send/transaction-builder.model.ts
+++ b/src/app/wallet/wallet/send/transaction-builder.model.ts
@@ -12,6 +12,7 @@ export class TransactionBuilder {
   address: string;
   amount: number;
   comment: string;
+  commentTo: string;
   narration: string;
   numsignatures: number = 1;
   validAddress: boolean;

--- a/src/app/wallet/wallet/send/transaction-builder.model.ts
+++ b/src/app/wallet/wallet/send/transaction-builder.model.ts
@@ -15,4 +15,5 @@ export class TransactionBuilder {
   privacy: number;
   subtractFeeFromAmount: boolean;
   note: string;
+  transactionFee: number;
 }

--- a/src/app/wallet/wallet/send/transaction-builder.model.ts
+++ b/src/app/wallet/wallet/send/transaction-builder.model.ts
@@ -20,8 +20,6 @@ export class TransactionBuilder {
   currency: string;
   ringsize: number;
   subtractFeeFromAmount: boolean;
-  note: string;
-  transactionFee: number;
 
   constructor() {
     // set default value


### PR DESCRIPTION
![](https://i.imgur.com/Bmnbaru.png)

- fixes #637 
- more previews for [blind TX](https://i.imgur.com/U1wEqBH.png) & [anon TX](https://i.imgur.com/Z1at8Hb.png)
- so far only static (= not working) layout → needs to be connected to the backend
- redesigned layout of TX confirmation modal
- added TX information (info about public/blind/anon TXs and their implications)
- added fee estimations
- added fiat countervalues (when ready to be implemented)

Note: this PR was based on @pciavald's https://github.com/particl/particl-desktop/pull/724 because I couldn't access the Send tab due to the bug on `dev`. If needed, I can rebase on `dev` when fixed.

### TODO

- [x] PRG: connect the static code to backend for live data (addresses, TX amounts etc.)