### PR TITLE
Sign/Verify modal Refactoring 

### DIFF
--- a/src/app/wallet/wallet/addresslookup/addresslookup.component.ts
+++ b/src/app/wallet/wallet/addresslookup/addresslookup.component.ts
@@ -5,6 +5,7 @@ import { Contact } from './contact.model';
 import { Log } from 'ng2-logger';
 import { AddressLookUpCopy } from '../models/address-look-up-copy';
 import { MatDialogRef } from '@angular/material';
+import { AddressHelper } from '../../shared/util/utils';
 
 @Component({
   selector: 'app-addresslookup',
@@ -19,10 +20,11 @@ export class AddressLookupComponent implements OnInit {
 
   log: any = Log.create('addresslookup.component');
 
-  filter: string = 'All types';
-  allowFilter: boolean = true;
-  query: string = '';
-  searchResult: Contact[];
+  public filter: string = 'All types';
+  public allowFilter: boolean = true;
+  public query: string = '';
+  public searchResult: Contact[];
+  private addressHelper: AddressHelper;
 
   public type: string = 'send';
   public addressTypes: Array<string> = ['All types', 'Public', 'Private'];
@@ -37,6 +39,7 @@ export class AddressLookupComponent implements OnInit {
 
   constructor(private _rpc: RpcService,
               private dialogRef: MatDialogRef<AddressLookupComponent>) {
+    this.addressHelper = new AddressHelper();
   }
 
   ngOnInit(): void {
@@ -102,9 +105,9 @@ export class AddressLookupComponent implements OnInit {
                 (success: any) => {
                   this.addressLookups = [];
                   success.forEach((contact) => {
-                    if (this.type === 'send' || contact.address.length > 35) {
+                    if (this.type === 'send' || this.addressHelper.testAddress(contact.address, 'private')) {
                       this.addressLookups.push(new Contact(contact.label, contact.address));
-                    } else if (this.type === 'sign' && contact.address.length < 35 && contact.owned) {
+                    } else if (this.type === 'sign' && this.addressHelper.testAddress(contact.address, 'public') && contact.owned) {
                       this.filter = 'Public';
                       this.addressLookups.push(new Contact(contact.label, contact.address));
                     }

--- a/src/app/wallet/wallet/addresslookup/addresslookup.component.ts
+++ b/src/app/wallet/wallet/addresslookup/addresslookup.component.ts
@@ -104,6 +104,9 @@ export class AddressLookupComponent implements OnInit {
                   success.forEach((contact) => {
                     if (this.type === 'send' || contact.address.length > 35) {
                       this.addressLookups.push(new Contact(contact.label, contact.address));
+                    } else if (this.type === 'sign' && contact.address.length < 35 && contact.owned) {
+                      this.filter = 'Public';
+                      this.addressLookups.push(new Contact(contact.label, contact.address));
                     }
                   })
                 },

--- a/src/app/wallet/wallet/shared/signature-address-modal/signature-address-modal.component.html
+++ b/src/app/wallet/wallet/shared/signature-address-modal/signature-address-modal.component.html
@@ -10,13 +10,16 @@
         <mat-tab label="Sign Message">
           <p>
             You can sign messages/agreements with your address to prove you can receive Particl sent to them. Be
-            careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.
+            careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your
+            identity over to them. Only sign fully-detailed statements you agree to.
           </p>
         </mat-tab>
         <mat-tab label="Verify Message">
           <p>
             Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs etc. exactly) and
-            signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!
+            signature below to verify the message. Be careful not to read more into the signature than what is in the
+            signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the
+            signing party receives with the address, it cannot prove sendership of any transaction!
           </p>
         </mat-tab>
       </mat-tab-group>
@@ -26,9 +29,9 @@
         <div class="address-field" fxLayout="row" fxLayoutAlign="center center">
           <mat-form-field fxFlex="1 1 100%">
             <input matInput formControlName="address" [(ngModel)]="formData.address" #addressInput
-                    [ngClass]="{'verify-sucess': validAddress === true, 'verify-error': validAddress === false }"
-                    placeholder="Enter a Particl address (e.g. PuMnFoGouqFkFZ1rs2PmVDUqp9psfQssre)"
-                    (input)="verifyAddress()">
+                   [ngClass]="{'verify-sucess': validAddress === true, 'verify-error': validAddress === false }"
+                   placeholder="Enter a Particl address (e.g. PuMnFoGouqFkFZ1rs2PmVDUqp9psfQssre)"
+                   (input)="verifyAddress()">
           </mat-form-field>
 
           <div class="icons" fxFlex="0 0 65px">
@@ -43,17 +46,28 @@
         </div><!-- .address-field -->
 
         <mat-form-field>
-          <textarea matInput formControlName="message" [(ngModel)]="formData.message" rows="10" cols="100" placeholder="Enter message to sign/verify"></textarea>
+          <textarea matInput formControlName="message" [(ngModel)]="formData.message" rows="10" cols="100"
+                    placeholder="Enter message to sign/verify"></textarea>
         </mat-form-field>
 
-        <mat-form-field>
-          <input matInput formControlName="signature" [(ngModel)]="formData.signature"
-                 [disabled]="isDisabled"
-                 placeholder="{{(type == 'sign')? 'Click [Sign Message] to generate signature': 'Signature'}}">
-        </mat-form-field>
-        <!-- todo: <mat-icon *ngIf="type == 'sign' && formData.signature" class="cursor-pointer" (click)="onCopyAddress()"
-                 matTooltip="Copy address" ngxClipboard
-                 [cbContent]="formData.signature" fontSet="partIcon" fontIcon="part-copy"></mat-icon>-->
+        <div class="address-field" fxLayout="row" fxLayoutAlign="center center">
+          <mat-form-field fxFlex="1 1 100%">
+            <input matInput formControlName="signature" [(ngModel)]="formData.signature"
+                   [disabled]="isDisabled"
+                   #signatureInput
+                   placeholder="{{(type == 'sign')? 'Click [Sign Message] to generate signature': 'Signature'}}">
+          </mat-form-field>
+
+          <div class="icons" fxFlex="0 0 45px">
+            <span class="icon" matTooltip="Copy" (click)="copyToClipBoard()" *ngIf="type == 'sign'" ngxClipboard
+                  [cbContent]="formData.signature">
+              <mat-icon class="cursor-pointer" fontSet="partIcon" fontIcon="part-copy"></mat-icon>
+            </span>
+            <span class="icon" matTooltip="Paste" (click)="pasteSignature()" *ngIf="type == 'verify'">
+              <mat-icon class="cursor-pointer" fontSet="partIcon" fontIcon="part-past"></mat-icon>
+            </span>
+          </div>
+        </div>
       </div><!-- .signature-address-modal-form -->
     </div>
     <mat-dialog-actions fxLayoutAlign="end center">

--- a/src/app/wallet/wallet/shared/signature-address-modal/signature-address-modal.component.ts
+++ b/src/app/wallet/wallet/shared/signature-address-modal/signature-address-modal.component.ts
@@ -71,7 +71,7 @@ export class SignatureAddressModalComponent implements OnInit {
   openLookup(): void {
     const dialogRef = this.dialog.open(AddressLookupComponent);
     // @TODO confirm lookup type
-    dialogRef.componentInstance.type = (this.type === 'sign') ? 'receive' : 'send';
+    dialogRef.componentInstance.type = (this.type === 'sign') ? 'sign' : 'send';
     dialogRef.componentInstance.filter = 'Public';
     dialogRef.componentInstance.selectAddressCallback.subscribe((response: AddressLookUpCopy) => {
       this.selectAddress(response);

--- a/src/app/wallet/wallet/shared/signature-address-modal/signature-address-modal.component.ts
+++ b/src/app/wallet/wallet/shared/signature-address-modal/signature-address-modal.component.ts
@@ -33,6 +33,7 @@ export class SignatureAddressModalComponent implements OnInit {
   log: any = Log.create('SignatureAddressModalComponent.component');
 
   @ViewChild('addressInput') addressInput: ElementRef;
+  @ViewChild('signatureInput') signatureInput: ElementRef;
 
   constructor(private dialog: MatDialog,
               private _rpc: RpcService,
@@ -152,12 +153,17 @@ export class SignatureAddressModalComponent implements OnInit {
     this.addressForm.reset();
   }
 
-  onCopyAddress(): void {
-    this.flashNotification.open('Copied address to clipboard!');
-  }
-
   pasteAddress(): void {
     this.addressInput.nativeElement.focus();
+    document.execCommand('paste');
+  }
+
+  copyToClipBoard(): void {
+    this.flashNotification.open('Signature copied to clipboard.');
+  }
+
+  pasteSignature(): void {
+    this.signatureInput.nativeElement.focus();
     document.execCommand('paste');
   }
 


### PR DESCRIPTION
In Sign Verify Modal

- **Sign Message**: Address lookup modal display private address not public and I guess we need to display public address in sign message > address lookup, so addresses lookup modal should be refactored. Also after signed address user got a signature key, There is no copy options, so I've added it. 


- **Verify Message**: Its work fine, addresse lookup show only address book address which user need to verify etc. Only here I added paste button for paste signature. 
https://github.com/particl/particl-desktop/issues/734