### PR TITLE
fix osx double pasting

### DIFF
--- a/src/app/core-ui/main/main-view.component.ts
+++ b/src/app/core-ui/main/main-view.component.ts
@@ -153,6 +153,7 @@ export class MainViewComponent implements OnInit, OnDestroy {
   keyDownEvent(event: any) {
     if (event.metaKey && event.keyCode === 86 && navigator.platform.indexOf('Mac') > -1) {
       document.execCommand('Paste');
+      event.preventDefault();
     }
   }
 


### PR DESCRIPTION
This commit adds an `event.preventDefault()` to avoid double pasting in os x, described in issue #817 