### PR TITLE
Adds new angularx-qrcode in qr-code-modal

### DIFF
--- a/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.html
+++ b/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.html
@@ -8,7 +8,7 @@
 
   <div class="qr-code">
     <div #qrCode class="card qr">
-      <qr-code [level]="'H'" size="150" value="particl:{{ singleAddress.address }}"></qr-code>
+      <qrcode [level]="'H'" size="150" qrdata="particl:{{ singleAddress.address }}"></qrcode>
     </div>
   </div>
 

--- a/src/assets/theme.scss
+++ b/src/assets/theme.scss
@@ -479,3 +479,11 @@ input {
 .capitalize {
   text-transform: capitalize;
 }
+
+// ------ QR-Code ------ //
+
+.qr-code {
+  img {
+    display: inline !important;
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -563,3 +563,9 @@ a.highlight {
   color: $color;
   text-decoration: none;
 }
+
+.qr-code {
+  img {
+    display: inline !important;
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -563,9 +563,3 @@ a.highlight {
   color: $color;
   text-decoration: none;
 }
-
-.qr-code {
-  img {
-    display: inline !important;
-  }
-}


### PR DESCRIPTION
Address Book QR not shown #835

Testing 1.1.0 RC 5 release.

Address Boot Tab, when trying to view the Address QR code using the "Show QR Code" button, only the address is available. No QR code are shown.