### PR TITLE
Hotfix for #952: sidebar tabs wont work anymore after clicking "Buy"

### DIFF
--- a/src/app/market/buy/checkout-process/checkout-process.component.ts
+++ b/src/app/market/buy/checkout-process/checkout-process.component.ts
@@ -77,7 +77,9 @@ export class CheckoutProcessComponent implements OnInit, OnDestroy {
   setShippingCache() {
     this.updateSteperIndex();
     this.profileService.shippingDetails = this.shippingFormGroup.value;
-    this.profileService.shippingDetails.id = this.selectedAddress && this.selectedAddress.id
+    if (this.selectedAddress) {
+      this.profileService.shippingDetails.id = this.selectedAddress.id
+    }
   }
 
   formBuild() {

--- a/src/app/market/buy/checkout-process/checkout-process.component.ts
+++ b/src/app/market/buy/checkout-process/checkout-process.component.ts
@@ -77,7 +77,7 @@ export class CheckoutProcessComponent implements OnInit, OnDestroy {
   setShippingCache() {
     this.updateSteperIndex();
     this.profileService.shippingDetails = this.shippingFormGroup.value;
-    this.profileService.shippingDetails.id = this.selectedAddress.id
+    this.profileService.shippingDetails.id = this.selectedAddress && this.selectedAddress.id
   }
 
   formBuild() {


### PR DESCRIPTION
Just quickfix for JS exception, probably it would be better to find out why `this.selectedAddress` is not defined on view destruction.