### PR TITLE
Fix #963: MP Add groups in selectable categories filter drop-down (var. A)

### DIFF
--- a/src/app/core/market/api/category/category.model.ts
+++ b/src/app/core/market/api/category/category.model.ts
@@ -3,7 +3,7 @@ export class Category {
   get name() { return this.category.name };
   get id() { return this.category.id };
 
-  constructor(private category: any) {
+  constructor(private category: any, private level: number = 0) {
     if (category.ChildItemCategories) {
       this.setSubCategoryList();
     }
@@ -12,7 +12,7 @@ export class Category {
   // get subcategories (single level)
   setSubCategoryList() {
     const list = this.category.ChildItemCategories;
-    this.subCategoryList = list.map(o => { return new Category(o)});
+    this.subCategoryList = list.map(o => { return new Category(o, this.level + 1) });
   }
 
   getSubCategory(): Array<any> {

--- a/src/app/market/listings/listings.component.html
+++ b/src/app/market/listings/listings.component.html
@@ -20,7 +20,7 @@
 
       <mat-select placeholder="All categories" (change)="clearAndLoadPage()" [(ngModel)]="filters.category"  class="filter category">
         <mat-option>All categories</mat-option>
-        <mat-option *ngFor="let category of categoryList" [value]="category.id">{{ category.name }}</mat-option>
+        <mat-option *ngFor="let category of categoryList" [value]="category.id"><span class="lvl-{{ category.level }}">{{ category.name }}</span></mat-option>
       </mat-select>
     </div>
 

--- a/src/app/market/listings/listings.component.scss
+++ b/src/app/market/listings/listings.component.scss
@@ -24,6 +24,24 @@
   }
 }
 
+
+// ------ CATEGORIES FILTER (top) ------ //
+
+.mat-option {
+  // filter by category top-level group
+  .lvl-1 {
+    margin-left: 0;
+  }
+  // filter by category sub-group/item
+  .lvl-2 {
+    margin-left: 16px !important;
+  }
+  // filter by category item
+  .lvl-3 {
+    margin-left: 32px !important;
+  }
+}
+
 // ------ CONTROL BAR (top) ------ //
 
 .control-bar {
@@ -69,7 +87,6 @@
     }
   }
 }
-
 
 // ------ SIDEBAR (left) ------ //
 

--- a/src/app/market/listings/listings.component.ts
+++ b/src/app/market/listings/listings.component.ts
@@ -34,7 +34,7 @@ export class ListingsComponent implements OnInit, OnDestroy {
   // countries: FormControl = new FormControl();
   search: string;
 
-  // TODO? "Select with option groups" - https://material.angular.io/components/select/overview#creating-groups-of-options
+
   // categories: FormControl = new FormControl();
   categoryList: Array<Category> = [];
 


### PR DESCRIPTION
In categories filter drop-down list options aligned according level in
hierarchy (down to 3rd level, only two levels added now)