### PR TITLE
error handling while bidding on order according to scenarios

### DIFF
--- a/src/app/core/market/api/bid/bid.service.ts
+++ b/src/app/core/market/api/bid/bid.service.ts
@@ -8,6 +8,10 @@ import { Cart } from 'app/core/market/api/cart/cart.model';
 import { Listing } from 'app/core/market/api/listing/listing.model';
 import { Bid } from 'app/core/market/api/bid/bid.model';
 
+export enum errorType {
+  unspent = 'No unspent outputs available. Please complete active locked escrow.',
+  broke = 'Insufficient funds to place the order.'
+}
 
 @Injectable()
 export class BidService {
@@ -31,7 +35,10 @@ export class BidService {
                   observer.next(true);
                   observer.complete();
                 }
-              }, observer.error);
+              }, (error) => {
+                error = error.includes('unspent') ? errorType.unspent : errorType.broke
+                observer.error(error)
+              });
         }
       });
     });

--- a/src/app/core/market/api/bid/bid.service.ts
+++ b/src/app/core/market/api/bid/bid.service.ts
@@ -10,8 +10,7 @@ import { Bid } from 'app/core/market/api/bid/bid.model';
 
 export enum errorType {
   unspent = 'Zero unspent outputs - insufficient funds to place the order.',
-  broke = 'Insufficient funds to place the order.',
-  other = 'Something went wrong'
+  broke = 'Insufficient funds to place the order.'
 }
 
 @Injectable()
@@ -41,8 +40,6 @@ export class BidService {
                   error = errorType.unspent;
                 } else if (error.includes('broke')) {
                   error = errorType.broke;
-                } else {
-                  error = errorType.other;
                 }
                 observer.error(error)
               });

--- a/src/app/core/market/api/bid/bid.service.ts
+++ b/src/app/core/market/api/bid/bid.service.ts
@@ -10,7 +10,8 @@ import { Bid } from 'app/core/market/api/bid/bid.model';
 
 export enum errorType {
   unspent = 'Zero unspent outputs - insufficient funds to place the order.',
-  broke = 'Insufficient funds to place the order.'
+  broke = 'Insufficient funds to place the order.',
+  other = 'Something went wrong'
 }
 
 @Injectable()
@@ -36,7 +37,13 @@ export class BidService {
                   observer.complete();
                 }
               }, (error) => {
-                error = error.includes('unspent') ? errorType.unspent : errorType.broke
+                if (error.includes('unspent')) {
+                  error = errorType.unspent;
+                } else if (error.includes('broke')) {
+                  error = errorType.broke;
+                } else {
+                  error = errorType.other;
+                }
                 observer.error(error)
               });
         }

--- a/src/app/core/market/api/bid/bid.service.ts
+++ b/src/app/core/market/api/bid/bid.service.ts
@@ -9,7 +9,7 @@ import { Listing } from 'app/core/market/api/listing/listing.model';
 import { Bid } from 'app/core/market/api/bid/bid.model';
 
 export enum errorType {
-  unspent = 'No unspent outputs available. Please complete active locked escrow.',
+  unspent = 'Zero unspent outputs - insufficient funds to place the order.',
   broke = 'Insufficient funds to place the order.'
 }
 

--- a/src/app/market/buy/checkout-process/checkout-process.component.ts
+++ b/src/app/market/buy/checkout-process/checkout-process.component.ts
@@ -216,6 +216,7 @@ export class CheckoutProcessComponent implements OnInit, OnDestroy {
       this.snackbarService.open('Order has been successfully placed');
       this.onOrderPlaced.emit(1);
     }, (error) => {
+      this.snackbarService.open(error, 'warn');
       this.log.d(`Error while placing an order`);
     });
   }


### PR DESCRIPTION
GUI error handling for "No unspent outputs" and "Insufficient funds"

If this is returned:

2018-05-22T09:17:08.315Z - warn: [api\services\BidActionService] You are too broke...
2018-05-22T09:17:08.318Z - info: [app] POST /api/rpc 404 129.336 ms - 81

Message should display as follow:

Insufficient funds to place the order.

And for this error:

2018-05-22T09:28:50.170Z - warn: [api\services\BidActionService] No unspent outputs
2018-05-22T09:28:50.173Z - info: [app] POST /api/rpc 404 87.016 ms - 77

Please display:

No unspent outputs available. Please complete active locked escrow.