### PR TITLE
Update bid search cmd param

### DIFF
--- a/src/app/core/market/market-cache/add-to-cart-cache.service.ts
+++ b/src/app/core/market/market-cache/add-to-cart-cache.service.ts
@@ -31,7 +31,7 @@ export class AddToCartCacheService implements OnDestroy {
   }
 
   update() {
-    this.marketState.register('bid', null, ['search', '*', '*', 'ASC'])
+    this.marketState.register('bid', null, ['search', 0, 9999, 'ASC'])
   }
 
   getBids() {


### PR DESCRIPTION
- Updated search cmd to fix error "page number should be number".

As now `bid search` cmd already updated everywhere except here.