### PR TITLE
Fixes bug in Send Anon to Public transfer

### DIFF
--- a/src/app/modals/send-confirmation-modal/send-confirmation-modal.component.ts
+++ b/src/app/modals/send-confirmation-modal/send-confirmation-modal.component.ts
@@ -13,6 +13,7 @@ import { SendService } from 'app/wallet/wallet/send/send.service';
 export class SendConfirmationModalComponent implements OnInit {
 
   @Output() onConfirm: EventEmitter<string> = new EventEmitter<string>();
+  @Output() onCancel: EventEmitter<string> = new EventEmitter<string>();
 
   public dialogContent: string;
   public send: TransactionBuilder;
@@ -37,6 +38,7 @@ export class SendConfirmationModalComponent implements OnInit {
   }
 
   dialogClose(): void {
+    this.onCancel.emit();
     this.dialogRef.close();
   }
 

--- a/src/app/wallet/wallet/send/send.component.ts
+++ b/src/app/wallet/wallet/send/send.component.ts
@@ -117,17 +117,17 @@ export class SendComponent implements OnInit {
 
   verifyAmount(): void {
 
-    if (this.send.amount === undefined || +this.send.amount === 0 || this.send.amount === null) {
-      this.send.validAmount = undefined;
-      return;
-    }
-
-    if ((this.send.amount + '').indexOf('.') >= 0 && (this.send.amount + '').split('.')[1].length > 8) {
+    if ( +(this.send.amount || 0) === 0 ) {
       this.send.validAmount = false;
       return;
     }
 
-    if (this.send.amount === 1e-8) {
+    // if ((this.send.amount + '').indexOf('.') >= 0 && (this.send.amount + '').split('.')[1].length > 8) {
+    //   this.send.validAmount = false;
+    //   return;
+    // }
+
+    if (+this.send.amount <= 1e-8) {
       this.send.validAmount = false;
       return;
     }
@@ -192,6 +192,13 @@ export class SendComponent implements OnInit {
 
     dialogRef.componentInstance.dialogContent = txt;
     dialogRef.componentInstance.send = this.send;
+
+    dialogRef.componentInstance.onCancel.subscribe(() => {
+      dialogRef.close();
+      if (this.type === 'balanceTransfer') {
+        this.send.toAddress = '';
+      }
+    });
 
     dialogRef.componentInstance.onConfirm.subscribe(() => {
       dialogRef.close();

--- a/src/app/wallet/wallet/send/send.service.ts
+++ b/src/app/wallet/wallet/send/send.service.ts
@@ -93,7 +93,7 @@ export class SendService {
       amount: tx.amount,
       subfee: tx.subtractFeeFromAmount,
       narr: tx.narration
-    }], tx.comment, tx.commentTo, tx.ringsize, 64, tx.estimateFeeOnly]);
+    }], tx.comment, tx.commentTo, tx.ringsize, 32, tx.estimateFeeOnly]);
   }
 
   private rpc_send_success(json: any, address: string, amount: number) {


### PR DESCRIPTION
This fixes 2 issues:
1. In Wallet > Send, transferring funds from Anon to Public resulted in an error due to an out of range value used for the inputs_per_sig field in the sendtypeto rpc command (fixed by now using the deamon default value),
2. After cancelling the modal asking for confirmation of a balance transfer, the user would need to manually clear the 'receiver address' input value in the Advanced section (automatically populated in a balance transfer), before being able to try another transfer (fixed by automatically clearing the receiver address value on cancel).

Also cleans up some unnecessary validation.