### PR TITLE
Proposal content fix

### DIFF
--- a/src/app/wallet/proposals/proposal-details/proposal-details.component.scss
+++ b/src/app/wallet/proposals/proposal-details/proposal-details.component.scss
@@ -75,6 +75,7 @@
         @extend %enable-select;
         color: $text-muted;
         white-space: pre-line;
+        word-break: break-all;
       }
       .authors {
         text-align: left;


### PR DESCRIPTION
I saw one issue on the proposal of the description content.
before fix: 
![before](https://user-images.githubusercontent.com/38350953/46857799-66e30300-ce27-11e8-9105-a52bd7636347.png)

I've fixed the same with the help of @AllienWorks.

After fix:

![after](https://user-images.githubusercontent.com/38350953/46857846-7eba8700-ce27-11e8-9e55-66434807eafd.png)
