### PR TITLE
fix warning & info icons in modal messages

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -300,7 +300,7 @@ p.info {
 }
 p.warning {
   &::before {
-    content: "\ea03"; // part-alert icon
+    content: "\ea02"; // part-alert icon
     color: $color-alert;
   }
   a {
@@ -313,7 +313,7 @@ p.warning {
 }
 p.info {
   &::before {
-    content: "\ea32"; // part-info icon
+    content: "\ea19"; // part-info icon
     color: $color-info;
   }
   a {


### PR DESCRIPTION
After icon update, the order of icons changed, which resulted in wrong icons being shown in `info` and `warning` messages in modals. Now fixed:

![screenshot from 2018-10-12 16-25-43](https://user-images.githubusercontent.com/1965795/46875343-c9de9500-ce3b-11e8-874a-50fbe3345e5b.png)

![screenshot from 2018-10-12 16-25-47](https://user-images.githubusercontent.com/1965795/46875345-cb0fc200-ce3b-11e8-8e3c-266f3cba6209.png)
