### PR TITLE
Shipping profile name only required if Save as shipping profile checkbox ticked

### DIFF
--- a/src/app/market/buy/checkout-process/checkout-process.component.html
+++ b/src/app/market/buy/checkout-process/checkout-process.component.html
@@ -163,7 +163,7 @@
               <br><br>
               To create a new shipping profile, fill out the form on the right and check "Save shipping profile".
             </p>
-            <button mat-button color="basic" class="small" [disabled]="!profile?.shippingAddresses || profile?.shippingAddresses.length === 0 || !addressNotSelected" (click)="clearForm()" matTooltip="When you want to enter shipping details manually instead">
+            <button mat-button color="basic" class="small" [disabled]="!profile?.shippingAddresses || profile?.shippingAddresses.length === 0 || (!selectedAddress?.id)" (click)="clearForm()" matTooltip="When you want to enter shipping details manually instead">
               <mat-icon class="icon" fontSet="partIcon" fontIcon="part-refresh"></mat-icon>
               Unselect Shipping profile
             </button>
@@ -216,6 +216,7 @@
               [placeHolder]="'Select Country'"
               [isRequired]="'true'"
               [defaultSelectedValue]="selectedCountry"
+              [isLexigraphicalOrder]="true"
               (onChange)="onCountryChange($event)">
             </mat-select-search>
             <!-- mat-select-search -->

--- a/src/app/market/buy/checkout-process/checkout-process.component.ts
+++ b/src/app/market/buy/checkout-process/checkout-process.component.ts
@@ -7,6 +7,7 @@ import { Router } from '@angular/router';
 import {
   FormBuilder,
   FormGroup,
+  FormControl,
   Validators
 } from '@angular/forms';
 import { Log } from 'ng2-logger';
@@ -132,7 +133,11 @@ export class CheckoutProcessComponent implements OnInit, OnDestroy {
       country: ['', Validators.required],
       zipCode: ['', Validators.required],
       newShipping: [''],
-      title: ['', Validators.required]
+      title: ['']
+    }, {
+      validator: (formGroup: FormGroup) => {
+        return this.validateShippingProfileTitle(formGroup);
+      }
     });
   }
 
@@ -230,10 +235,6 @@ export class CheckoutProcessComponent implements OnInit, OnDestroy {
     this.shippingFormGroup.reset();
   }
 
-  get addressNotSelected(): boolean {
-    return Object.keys(this.selectedAddress).length > 0
-  }
-
   getProfile(): void {
     this.profileService.default().take(1).subscribe(
       (profile: any) => {
@@ -295,7 +296,24 @@ export class CheckoutProcessComponent implements OnInit, OnDestroy {
     });
   }
 
+  private validateShippingProfileTitle(formGroup: FormGroup): any | null {
+    let isValid = true;
+    const newShippingControl: FormControl = <FormControl>formGroup.controls.newShipping;
+    if (newShippingControl.value) {
+      const titleControl: FormControl = <FormControl>formGroup.controls.title;
+      isValid = titleControl.value && titleControl.value.length > 0;
+    }
 
+    if (isValid) {
+      return null;
+    }
+
+    return {
+      validateShippingProfileTitle: {
+        valid: isValid
+      }
+    }
+  }
 
 
   /*


### PR DESCRIPTION
Updates the validation for the Shipping Profile name in the buy flow process to only validate the input if the 'Save as shipping profile' checkbox is ticked.

Refers to https://particl.atlassian.net/browse/PD-304 