### PR TITLE
GFX tweaks & Address details (modal)

### DIFF
--- a/src/app/modals/coldstake/coldstake.component.ts
+++ b/src/app/modals/coldstake/coldstake.component.ts
@@ -100,8 +100,8 @@ export class ColdstakeComponent {
   setColdStakingAddress(): void {
     if (this.prevColdStakeAddress === this.coldStakeAddress) {
       if (this.step === 2) {
-        this.finalMessage = 'Cold staking address is the same - no changes required.';
-        this._flashNotificationService.open('Cold staking key is exactly the same as before!', 'warn');
+        this.finalMessage = 'Cold staking address is the same - no changes required';
+        this._flashNotificationService.open('Cold staking key has not changed', 'warn');
       }
       return;
     }
@@ -110,7 +110,7 @@ export class ColdstakeComponent {
       .subscribe(
         success => {
           this.log.d(`setColdStakingAddress: set changeaddress: ${success.changeaddress.coldstakingaddress}`);
-          this._flashNotificationService.open('Successfully activated cold staking!', 'info');
+          this._flashNotificationService.open('Cold staking successfully activated', 'info');
           this._rpcState.set('ui:coldstaking', true);
           this.close();
         },
@@ -125,7 +125,7 @@ export class ColdstakeComponent {
       .subscribe(
         success => {
           this.log.d(`resetColdStakeAddress: set changeaddress: ${success.changeaddress.coldstakingaddress}`);
-          this._flashNotificationService.open('Successfully deactivated cold staking!', 'info');
+          this._flashNotificationService.open('Cold staking successfully deactivated', 'info');
           this.close();
         },
         error => {

--- a/src/app/wallet/help/help.component.html
+++ b/src/app/wallet/help/help.component.html
@@ -34,6 +34,16 @@
       <mat-card class="card">
         <div class="list section">
 
+          <a class="item" href="https://particl.community" target="_blank">
+            <div class="icon">
+              <mat-icon fontSet="partIcon" fontIcon="part-chat-discussion"></mat-icon>
+            </div>
+            <div class="text">
+              <div class="title">Forums</div>
+              <p class="desc">Official Particl forums &ndash; the best place for conversation</p>
+            </div>
+          </a>
+          
           <a class="item" href="https://riot.im/app/#/group/+particl:matrix.org" target="_blank">
             <div class="icon">
               <mat-icon fontSet="partIcon" fontIcon="part-riot"></mat-icon>
@@ -180,6 +190,23 @@
             <div class="text">
               <div class="title">Wiki</div>
               <p class="desc">Write tutorials &amp; translate to your language</p>
+            </div>
+          </a>
+
+        </div>
+      </mat-card>
+
+      <div class="subtitle">Get PART <span class="tag">Buy/Sell</span></div>
+      <mat-card class="card">
+        <div class="list section">
+
+          <a class="item" href="https://particl.io/part-exchanges" target="_blank">
+            <div class="icon">
+                <mat-icon fontSet="partIcon" fontIcon="part-swap"></mat-icon>
+            </div>
+            <div class="text">
+              <div class="title">Exchanges</div>
+              <p class="desc">Buy/sell Particl on these Exchanges (crypto/fiat)</p>
             </div>
           </a>
 

--- a/src/app/wallet/overview/overview.component.html
+++ b/src/app/wallet/overview/overview.component.html
@@ -56,17 +56,15 @@
       </mat-card>
     </div>.seller-overview -->
 
-    <div class="recent-transactions">
-      <app-header>
-        <ul class="header-nav">
-          <li>Recent Transactions</li>
-          <!-- TODO: uncomment when widget management is ready -->
-          <!--li class="buttons">
-            <mat-icon class="icon" fontSet="partIcon" fontIcon="part-cog" matTooltip="Edit widget"></mat-icon>
-            <mat-icon class="icon move" fontSet="partIcon" fontIcon="part-hamburger" matTooltip="Move widget"></mat-icon>
-          </li-->
-        </ul>
-      </app-header>
+    <div class="recent-transactions section">
+      <header>
+        <div class="subtitle">Recent Transactions</div>
+        <!-- TODO: uncomment when widget management is ready -->
+        <!--div class="buttons">
+          <mat-icon class="icon" fontSet="partIcon" fontIcon="part-cog" matTooltip="Edit widget"></mat-icon>
+          <mat-icon class="icon move" fontSet="partIcon" fontIcon="part-hamburger" matTooltip="Move widget"></mat-icon>
+        </div-->
+      </header>
       <transaction-table
         [display]="{'txDisplayAmount': 5, 'header': false, 'internalHeader': true, 'category': true, 'confirmations': true}">
       </transaction-table>

--- a/src/app/wallet/overview/widgets/coldstake/coldstake.component.html
+++ b/src/app/wallet/overview/widgets/coldstake/coldstake.component.html
@@ -65,9 +65,8 @@
     </p>
   </mat-card>
   <p class="widget-help" *ngIf="_coldstake.coldStakingEnabled">
-    {{_coldstake.coldstakeProgress}}% of your balance is now safely staking on your staking node.
+    {{_coldstake.coldstakeProgress}}% of your balance is now cold staking.
     The activation process will continue only when your wallet is online and unlocked for staking.
-    You can close your wallet if you need to, but it is advised to keep it online until it reaches 100%.
   </p>
 
   <!-- if wallet is locked, & under < 100% progress -->

--- a/src/app/wallet/overview/widgets/coldstake/coldstake.component.html
+++ b/src/app/wallet/overview/widgets/coldstake/coldstake.component.html
@@ -1,9 +1,7 @@
-<div class="cold-staking">
-  <app-header>
-    <ul class="header-nav">
-      <li class="section-title">Cold Staking</li>
-    </ul>
-  </app-header>
+<div class="cold-staking section">
+  <header>
+    <div class="subtitle">Cold Staking</div>
+  </header>
 
   <mat-card *ngIf="_coldstake.walletInitialized !== true" class="staking-node inactive">
     <div class="title">Cold Staking Node</div>
@@ -11,7 +9,7 @@
   </mat-card>
 
   <mat-card *ngIf="_coldstake.walletInitialized && _coldstake.coldStakingEnabled === undefined" class="staking-node inactive">
-    <button mat-raised-button color="primary" class="pull-left" (click)="openUnlockWalletModal()" matTooltip="Unlock wallet to enable cold staking">
+    <button mat-raised-button color="primary" (click)="openUnlockWalletModal()" matTooltip="Unlock wallet to enable cold staking">
       <mat-icon fontSet="partIcon" fontIcon="part-lock"></mat-icon>
     </button>
     <div class="title">Cold Staking Node</div>
@@ -19,14 +17,14 @@
   </mat-card>
 
   <mat-card *ngIf="_coldstake.walletInitialized && !_coldstake.coldStakingEnabled" class="staking-node inactive">
-    <button mat-raised-button color="primary" class="pull-left" (click)="openColdStakeModal()" matTooltip="Add Cold Staking node key">
+    <button mat-raised-button color="primary" (click)="openColdStakeModal()" matTooltip="Add Cold Staking node key">
       <mat-icon fontSet="partIcon" fontIcon="part-plus"></mat-icon>
     </button>
     <div class="title">Cold Staking Node</div>
     <div class="subtitle">Inactive</div>
   </mat-card>
 
-  <p class="widget-help" *ngIf="_coldstake.walletInitialized && _coldstake.coldStakingEnabled">
+  <p class="widget-help" *ngIf="_coldstake.walletInitialized && !_coldstake.coldStakingEnabled">
     Cold staking allows you to spend from one machine and stake from another, this greatly increases the safety of your coins.
   </p>
 
@@ -56,29 +54,21 @@
       [mode]="'determinate'"
       [value]="_coldstake.coldstakeProgress">
     </mat-progress-bar>
-    <p class="widget-help" *ngIf="_coldstake.coldStakingEnabled">
-      {{_coldstake.coldstakeProgress}}% of your balance is now safely staking on your staking node.
-      The activation process will continue only when your wallet is online and unlocked for staking.
-      You can close your wallet if you need to, but it is advised to keep it online until it reaches 100%.
-    </p>
     <!-- TODO: component ? -->
     <p class="buttons">
-      <button mat-button class="small" color="primary"
-        matTooltip="Fast-forward to 100%"
-        (click)="zap()"
-        *ngIf="_coldstake.hotstake.txs.length">
+      <button mat-button class="small" color="primary" matTooltip="Fast-forward to 100%" (click)="zap()" *ngIf="_coldstake.hotstake.txs.length">
         Zap
-        <!-- <span class="tag zap">{{ hotstaking.txs.length }}</span> -->
       </button>
-      <button mat-button class="small" color="warn"
-        matTooltip="Disable Cold Staking"
-        (click)="revert()"
-        >
+      <button mat-button class="small" color="warn" matTooltip="Disable Cold Staking" (click)="revert()">
         Disable
-        <!-- <span class="tag cancel">{{ coldstaking.txs.length }}</span> -->
       </button>
     </p>
   </mat-card>
+  <p class="widget-help" *ngIf="_coldstake.coldStakingEnabled">
+    {{_coldstake.coldstakeProgress}}% of your balance is now safely staking on your staking node.
+    The activation process will continue only when your wallet is online and unlocked for staking.
+    You can close your wallet if you need to, but it is advised to keep it online until it reaches 100%.
+  </p>
 
   <!-- if wallet is locked, & under < 100% progress -->
   <mat-card *ngIf=" _coldstake.coldStakingEnabled && _coldstake.coldstakeProgress < 100 && !checkLockStatus()" class="staking-node warning">

--- a/src/app/wallet/overview/widgets/coldstake/coldstake.component.scss
+++ b/src/app/wallet/overview/widgets/coldstake/coldstake.component.scss
@@ -38,7 +38,7 @@
       margin: 5px 0 15px;
     }
     .buttons { // Zap/revert buttons
-      margin: -12px 0;
+      margin: 0 0 24px;
       button {
         margin: 0;
         .tag {

--- a/src/app/wallet/overview/widgets/coldstake/revert-coldstaking/revert-coldstaking.component.html
+++ b/src/app/wallet/overview/widgets/coldstake/revert-coldstaking/revert-coldstaking.component.html
@@ -1,33 +1,30 @@
 <h2 mat-dialog-title>Disable Cold Staking</h2>
 
+
 <mat-dialog-content>
-  <p>
+  <p class="lead">
     Disable Cold Staking and move your funds back to your wallet from your staking device.
-    Note that you don't need to disable Cold Staking to spend your coins.
   </p>
-  <p>
-    Staked coins won't be affected. If the outputs you want to move are in your staked balance, you must wait for them to mature.
-  </p>
-  <!--p>
-    Alternatively, you can just disable Cold Staking activation. That will stop sending staked coins to your staking device. Coins already there will stay there.
-  </p-->
   <p class="warning">
-    <mat-icon fontSet="partIcon" fontIcon="part-alert"></mat-icon>
     Disabling Cold Staking will create {{ utxos.txs.length }} transaction(s) and will consume <strong>{{ fee }} PART</strong> in fees.
+  </p>
+  <p class="widget-help">
+    Note that you don't need to disable Cold Staking to spend your coins.<br>
+    Staked coins won't be affected. If the outputs you want to move are in your staked balance, you must wait for them to mature.
   </p>
 </mat-dialog-content>
 
+
 <mat-dialog-actions fxLayoutAlign="end center">
+
   <button mat-button mat-dialog-close>
     <mat-icon fontSet="partIcon" fontIcon="part-cross"></mat-icon>
     Cancel
   </button>
-  <!--button mat-button color="warn" (click)="disableColdstaking()">
-    <mat-icon fontSet="partIcon" fontIcon="part-error"></mat-icon>
-    Disable Cold Staking
-  </button-->
+
   <button mat-raised-button color="warn" (click)="revert()">
     <mat-icon fontSet="partIcon" fontIcon="part-refresh"></mat-icon>
     Disable Cold Staking
   </button>
+
 </mat-dialog-actions>

--- a/src/app/wallet/overview/widgets/coldstake/zap-coldstaking/zap-coldstaking.component.html
+++ b/src/app/wallet/overview/widgets/coldstake/zap-coldstaking/zap-coldstaking.component.html
@@ -1,28 +1,34 @@
 <h2 mat-dialog-title>Cold Stake Zap</h2>
 
+
 <mat-dialog-content>
-  <p>
-    Zapping will fast-forward the cold staking progress instantly to 100%.
+
+  <p class="lead">
+    Zapping will fast-forward the cold staking progress instantly to 100%
+  </p>
+  <p class="warning">
+    Zapping transaction(s) will consume <strong>{{ fee }} PART</strong> fee in the process.
   </p>
   <p>
     Be warned, that this decreases your financial privacy, as it bundles all your remaining coins into one big transaction. It is advised to zap only the small remaining part of your coins (last ~10 %) &ndash; those that take ages to get processed.
   </p>
-  <p>
+  <p class="widget-help">
     Staked coins won't be affected. If the outputs you want to move are in your staked balance, you must wait for them to mature.
   </p>
-  <p class="warning">
-    <mat-icon fontSet="partIcon" fontIcon="part-alert"></mat-icon>
-    Zapping transaction(s) will consume <strong>{{ fee }} PART</strong> fee in the process.
-  </p>
+
 </mat-dialog-content>
 
+
 <mat-dialog-actions fxLayoutAlign="end center">
+
   <button mat-button mat-dialog-close>
     <mat-icon fontSet="partIcon" fontIcon="part-cross"></mat-icon>
     Cancel
   </button>
+
   <button mat-raised-button color="warn" (click)="zap()" [disabled]="!fee">
     <mat-icon fontSet="partIcon" fontIcon="part-lightning"></mat-icon>
     Zap to 100%
   </button>
+
 </mat-dialog-actions>

--- a/src/app/wallet/overview/widgets/shared/shared.scss
+++ b/src/app/wallet/overview/widgets/shared/shared.scss
@@ -3,30 +3,32 @@
   Values shared among widgets
 */
 
-.header-nav { // overview section titles
-  @extend %subtitle;
-  list-style-type: none;
-  li {
-    display: inline-block;
-  }
-  .buttons { // widget control buttons
-    float: right;
-    margin-top: 2px;
-    .mat-icon {
-      @extend %tfx;
-      margin-left: 6px;
-      font-size: 14px;
-      color: $text-muted;
-      opacity: 0.5;
-      cursor: pointer;
-      &:hover {
-        opacity: 1;
-        color: $text;
-      }
-      &.move {
-        cursor: move;
+.section { // overview section titles
+  header {
+    .subtitle {
+      @extend %subtitle;
+    }
+    /*
+    .buttons { // widget control buttons
+      float: right;
+      margin-top: 2px;
+      .mat-icon {
+        @extend %tfx;
+        margin-left: 6px;
+        font-size: 14px;
+        color: $text-muted;
+        opacity: 0.5;
+        cursor: pointer;
+        &:hover {
+          opacity: 1;
+          color: $text;
+        }
+        &.move {
+          cursor: move;
+        }
       }
     }
+    */
   }
 }
 

--- a/src/app/wallet/overview/widgets/stakinginfo/stakinginfo.component.html
+++ b/src/app/wallet/overview/widgets/stakinginfo/stakinginfo.component.html
@@ -1,29 +1,23 @@
-<div class="staking-info">
-  <app-header>
-    <ul class="header-nav">
-      <li>Staking stats</li>
-    </ul>
-    <!--ul class="header-nav pull-right">
-      <li><a href="javascript:void(0)"><span class="icon fa fa-cog color-green"></span></a></li>
-    </ul-->
-  </app-header>
+<div class="staking-info section">
+  <header>
+    <div class="subtitle">Staking stats</div>
+  </header>
+
   <mat-card>
     <table class="staking-overview" cellspacing="0">
       <tr>
         <th>Next reward</th>
-        <td>~{{expectedtime.getShortReadableDuration()}}</td>
+        <td>~{{ expectedtime.getShortReadableDuration() }}</td>
       </tr>
       <tr>
         <th>Your Stake weight</th>
-        <!-- (your weight) / (network weight) * 1000 -->
-        <td>{{ownPercentageOfActiveStakingSupply.getIntegerPart()}}.<small>{{ownPercentageOfActiveStakingSupply.getFractionalPart()}}</small>&nbsp;&permil;</td>
+        <td>{{ ownPercentageOfActiveStakingSupply.getIntegerPart() }}.<small>{{ ownPercentageOfActiveStakingSupply.getFractionalPart() }}</small>&nbsp;%</td>
       </tr>
       <tr>
         <th>Stake percentage</th>
-        <td>{{curStakeReward.getIntegerPart()}}.<small>{{curStakeReward.getFractionalPart()}}</small>&nbsp;%</td>
+        <td>{{ curStakeReward.getIntegerPart() }}&nbsp;%</td>
       </tr>
     </table>
-    <!-- .staking-overview -->
   </mat-card>
-</div>
-<!-- .staking-info -->
+
+</div><!-- .staking-info -->

--- a/src/app/wallet/overview/widgets/stakinginfo/stakinginfo.component.ts
+++ b/src/app/wallet/overview/widgets/stakinginfo/stakinginfo.component.ts
@@ -86,7 +86,7 @@ export class StakinginfoComponent implements OnDestroy {
   }
 
   private calculateDynamicStakingReward(): void {
-    this.ownPercentageOfActiveStakingSupply = new Amount((this.weight / this.netstakeweight) * 1000, 5);
+    this.ownPercentageOfActiveStakingSupply = new Amount((this.weight / this.netstakeweight) * 100, 5);
     this.dynamicStakingReward = new Amount(this.curStakeReward.getAmount() * (this.moneysupply / (this.netstakeweight / 10000000)), 2);
 
     this.log.d(`calculateDynamicStakingReward, dynamicStakingReward = ${this.dynamicStakingReward}`);

--- a/src/app/wallet/shared/delete-confirmation-modal/delete-confirmation-modal.component.html
+++ b/src/app/wallet/shared/delete-confirmation-modal/delete-confirmation-modal.component.html
@@ -1,16 +1,18 @@
-<div mat-dialog-title>Delete address?</div>
+<div mat-dialog-title>Delete address</div>
 <button class="small-close_button" (click)="dialogClose()">
   <mat-icon fontSet="partIcon" fontIcon="part-circle-remove"></mat-icon>
 </button>
 
+
 <div mat-dialog-content class="dialog-content">
-  <p>
+  <p class="lead">
     Are you sure you want to delete this address from your Address book?
   </p>
-  <p>
+  <code class="address-details">
     {{ dialogContent }}
-  </p>
+  </code>
 </div>
+
 
 <mat-dialog-actions fxLayoutAlign="end center">
   <button mat-button mat-dialog-close (click)="dialogClose()">

--- a/src/app/wallet/shared/delete-confirmation-modal/delete-confirmation-modal.component.scss
+++ b/src/app/wallet/shared/delete-confirmation-modal/delete-confirmation-modal.component.scss
@@ -1,0 +1,13 @@
+@import "./src/assets/config"; // import shared colors etc.
+
+.address-details { // address details to be deleted
+   display: block;
+   padding: 16px 32px;
+   text-align: center;
+   font-size: 15px;
+   line-height: 1.4;
+   color: $color-alert;
+   background: rgba($color-alert, 0.12);
+   border-radius: 3px;
+   word-wrap: break-word;
+}

--- a/src/app/wallet/wallet/address-book/modal/new-address-modal/new-address-modal.component.html
+++ b/src/app/wallet/wallet/address-book/modal/new-address-modal/new-address-modal.component.html
@@ -1,27 +1,41 @@
-<div mat-dialog-title>{{modalTitle}}</div>
+<div mat-dialog-title>{{ modalTitle }}</div>
 <button class="small-close_button pull-right" tabindex="-1" (click)="closeModal()">
   <mat-icon fontSet="partIcon" fontIcon="part-circle-remove"></mat-icon>
 </button>
 
 <form [formGroup]="addAddressBookForm" (ngSubmit)="onSubmitForm()" novalidate>
   <div mat-dialog-content>
-    <mat-form-field>
-      <input matInput type="text" formControlName="address"
-             [(ngModel)]="address" (ngModelChange)="verifyAddress()"
-             placeholder="Enter Address"
-             [ngClass]="{'verify-sucess': checkAddress() == true, 'verify-error': checkAddress() == false }"
-             #addressInput
-             required>
+
+    <p class="lead">
+      Save 3rd-party's address (e.g. your friend's) for later use.
+    </p>
+    <p class="widget-help">
+      Keep in mind that re-using same Public addresses for multiple transactions decreases privacy. It is recommended to use Private addresses or ask the other party for a fresh Public address for each transaction.
+    </p>
+
+    <div class="address">
+      <mat-form-field class="address-field full-width larger">
+        <input matInput type="text" formControlName="address"
+               [(ngModel)]="address" (ngModelChange)="verifyAddress()"
+               placeholder="Enter Address"
+               [ngClass]="{'verify-sucess': checkAddress() == true, 'verify-error': checkAddress() == false }"
+               #addressInput
+               required>
+      </mat-form-field>
+      <button mat-button class="paste small" (click)="pasteAddress()">
+        <mat-icon class="cursor-pointer" fontSet="partIcon" fontIcon="part-past"></mat-icon>
+        Paste
+      </button>
+    </div>
+
+
+    <mat-form-field class="full-width larger">
+      <input matInput type="text" placeholder="Address label (e.g. owner's name)" name="label" formControlName="label" [(ngModel)]="label" required>
     </mat-form-field>
-    <!-- @TODO: CRZ please replace copy icon to paste icon-->
-    <span matTooltip="Paste" (click)="pasteAddress()">
-      <mat-icon class="cursor-pointer" fontSet="partIcon" fontIcon="part-copy"></mat-icon>
-    </span>
-    <mat-form-field>
-      <input matInput type="text" placeholder="Enter Label" name="label" formControlName="label" [(ngModel)]="label"
-             required />
-    </mat-form-field>
-  </div>
+
+  </div><!-- mat-dialog-content -->
+
+
   <mat-dialog-actions fxLayoutAlign="end center">
     <button type="button" mat-button mat-dialog-close (click)="closeModal()">
       <mat-icon fontSet="partIcon" fontIcon="part-cross"></mat-icon>
@@ -32,4 +46,5 @@
       Add Address
     </button>
   </mat-dialog-actions>
+
 </form>

--- a/src/app/wallet/wallet/address-book/modal/new-address-modal/new-address-modal.component.html
+++ b/src/app/wallet/wallet/address-book/modal/new-address-modal/new-address-modal.component.html
@@ -4,7 +4,7 @@
 </button>
 
 <form [formGroup]="addAddressBookForm" (ngSubmit)="onSubmitForm()" novalidate>
-  <div mat-dialog-content>
+  <div mat-dialog-content class="dialog-content">
 
     <p class="lead">
       Save 3rd-party's address (e.g. your friend's) for later use.

--- a/src/app/wallet/wallet/address-book/modal/new-address-modal/new-address-modal.component.scss
+++ b/src/app/wallet/wallet/address-book/modal/new-address-modal/new-address-modal.component.scss
@@ -1,0 +1,18 @@
+@import "./src/assets/config"; // import shared colors etc.
+
+.mat-dialog-content {
+  max-width: 500px;
+}
+
+.address {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  .address-field {
+    flex: 1 1 100%;
+  }
+  .paste {
+    flex: 0 0 50px;
+    margin-left: 12px;
+  }
+}

--- a/src/app/wallet/wallet/address-book/modal/new-address-modal/new-address-modal.component.ts
+++ b/src/app/wallet/wallet/address-book/modal/new-address-modal/new-address-modal.component.ts
@@ -48,7 +48,7 @@ export class NewAddressModalComponent implements OnInit {
       this.verifyAddress();
       this.modalTitle = 'Edit address';
     } else {
-      this.modalTitle = 'Add new address to Address book';
+      this.modalTitle = 'Add new address';
     }
     this.buildForm();
   }
@@ -81,12 +81,12 @@ export class NewAddressModalComponent implements OnInit {
    */
   onSubmitForm(): void {
     if (!this.validAddress) {
-      this.flashNotificationService.open('Please enter a valid address!');
+      this.flashNotificationService.open('Please enter a valid address');
       return;
     }
 
     if (this.isMine) {
-      this.flashNotificationService.open('This is your own address - can not be added to Address book!');
+      this.flashNotificationService.open('Your own address can not be saved to Address Book');
       return;
     }
 
@@ -109,8 +109,8 @@ export class NewAddressModalComponent implements OnInit {
   rpc_addAddressToBook_success(json: any): void {
     if (json.result === 'success') {
       this.closeModal();
-      const message: string = (this.isEdit) ? 'Address successfully updated to the Address book'
-        : 'Address successfully added to the Address book';
+      const message: string = (this.isEdit) ? 'Address successfully updated'
+        : 'Address successfully added';
 
       this.flashNotificationService.open(message);
       // TODO: remove specialPoll! (updates the address table)
@@ -157,7 +157,7 @@ export class NewAddressModalComponent implements OnInit {
 
           if (this.isMine) {
             this.flashNotificationService
-            .open('This is your own address - can not be added to Address book!', 'err');
+            .open('Your own address can not be saved to Address Book', 'err');
           }
         },
         error => this.log.er('rpc_validateaddress_failed'));

--- a/src/app/wallet/wallet/address-book/modal/new-address-modal/new-address-modal.component.ts
+++ b/src/app/wallet/wallet/address-book/modal/new-address-modal/new-address-modal.component.ts
@@ -140,7 +140,7 @@ export class NewAddressModalComponent implements OnInit {
    * Verify if address is valid through RPC call and set state to validAddress..
    */
   verifyAddress() {
-    if (this.address === undefined || this.address === '') {
+    if (!this.address) {
       this.validAddress = undefined;
       this.isMine = undefined;
       return;

--- a/src/app/wallet/wallet/receive/receive.component.html
+++ b/src/app/wallet/wallet/receive/receive.component.html
@@ -95,34 +95,35 @@
 
     <div *ngIf="getSinglePage().length" class="list-data">
       <div class="address-title">Used addresses</div>
-      <div *ngFor="let address of getSinglePage()" (click)="openNewAddress(address)">
+      <div *ngFor="let address of getSinglePage()">
 
         <mat-card class="address-info">
-          <div fxFlex="100%" fxLayout="row" fxLayoutAlign="center center" fxLayoutGap="10px" layout-padding>
-            <div fxFlex="0 0 45px" class="address-id">/{{ address.id }}</div>
-            <div fxFlex="1 1 20%" class="address-label cursor-pointer" [ngClass]="{'no-label': address.label === '(No label)'}" matTooltip="Edit label" matTooltipPosition="before">
-              {{ address.label }}
+          <div fxFlex="1 1 calc(100% - 79px)">
+            <div fxFlex="0 0 55px" class="address-id">
+              /{{ address.id }}
             </div>
-            <div fxFlex="1 1 80%" fxFlex.lt-md="40px" class="address enable-select">
-              {{ address.address }}
-              <!--div class="total"><span>Total received: </span>
-                <span class="received-amount">{{ address.balance }}</span>
-              </div-->
-            </div>
-            <div class="address-actions" fxFlex="0 0 50px" fxLayoutAlign="end center" fxLayoutGap="10px">
-              <!-- Copy address -->
-              <span fxFlex="50%">
-                <mat-icon fontSet="partIcon" fontIcon="part-copy" class="cursor-pointer"
-                          matTooltip="Copy address" (click)="copyToClipBoard()"
-                          ngxClipboard [cbContent]="address.address"></mat-icon>
+            <div fxFlex="1 1 90%" class="address-name cursor-pointer" (click)="openNewAddress(address)">
+              <span class="address-label" [ngClass]="{'no-label': address.label === '(No label)'}">
+                {{ address.label }}
               </span>
-              <!-- Sign/Verify public address only  -->
-              <span fxFlex="50%" *ngIf="type == 'public'">
-                <mat-icon fontSet="partIcon" fontIcon="part-person-check" matTooltip="Sign / Verify message"
-                          (click)="openSignatureModal(address.address)" class="cursor-pointer" ngxClipboard></mat-icon>
+              <span class="address">
+                {{ address.address }}
               </span>
             </div>
           </div>
+          <div class="address-actions" fxFlex="0 0 50px" fxLayoutAlign="end center">
+            <!-- Copy address -->
+            <span fxFlex="50%">
+              <mat-icon fontSet="partIcon" fontIcon="part-copy" class="cursor-pointer"
+                        matTooltip="Copy address" (click)="copyToClipBoard()"
+                        ngxClipboard [cbContent]="address.address"></mat-icon>
+            </span>
+            <!-- Sign/Verify public address only  -->
+            <span fxFlex="50%" *ngIf="type == 'public'">
+              <mat-icon fontSet="partIcon" fontIcon="part-person-check" matTooltip="Sign / Verify message"
+                        (click)="openSignatureModal(address.address)" class="cursor-pointer" ngxClipboard></mat-icon>
+            </span>
+          </div><!-- .address-actions -->
         </mat-card>
 
       </div>

--- a/src/app/wallet/wallet/receive/receive.component.html
+++ b/src/app/wallet/wallet/receive/receive.component.html
@@ -23,60 +23,7 @@
 <div  class="container-flex with-tab-bar">
 
   <mat-card class="receive-address">
-    <div class="address-info" fxLayout>
-
-      <div class="sidebar" fxFlex="0 0 180px">
-        <!-- QR code -->
-        <div #qrCode class="qrcode">
-          <qrcode size="180" [level]="'H'" qrdata="particl:{{ selected?.address }}">
-          </qrcode>
-        </div><!-- qrcode -->
-      </div>
-  
-      <div class="main" fxFlex="1 1 480px">
-  
-        <!-- Address type (public/private)-->
-        <div class="address-type">
-          <mat-icon *ngIf="getAddressType() === 'public'" fontSet="partIcon" fontIcon="part-public"></mat-icon>
-          <mat-icon *ngIf="getAddressType() === 'private'" fontSet="partIcon" fontIcon="part-anon"></mat-icon>
-          {{ getAddressType() }} address #{{ selected?.id }}
-        </div>
-  
-        <!-- Address label -->
-        <div class="address-label">
-          <!--
-            FIXME/TODO:
-              1. default state: disabled input + "edit label" icon (pen-1)
-              2. when user clicks on "edit label" icon, input gets enabled + icon switches to "save label"
-              3. when user saves label, input value gets updated, input becomes disabled again + icon switches back to "edit label"
-            =====
-              4. remove `add-address-label` component/modal
-              5. new addresses will be created with default label as "address #51" (according to their {{ address.id }})
-          -->
-          <mat-form-field class="icon-input label-input full-width">
-            <input matInput class="label" type="text" value="{{ selected?.label }}" [ngClass]="{'no-label': selected?.label === '(No label)'}" [disabled]="addressInput" [(ngModel)]="label" (keyup.enter)="updateLabel(getUnusedAddress().address)">
-            <mat-icon matTooltip="Edit label" *ngIf="addressInput" fontSet="partIcon" fontIcon="part-pen-1" (click)="changeLabel()"></mat-icon>
-            <mat-icon matTooltip="Save label" *ngIf="!addressInput" fontSet="partIcon" fontIcon="part-circle-check" (click)="updateLabel(getUnusedAddress().address)"></mat-icon>
-          </mat-form-field>
-        </div><!-- .address-label -->
-  
-        <!-- Address string -->
-        <div class="address address-string" fxLayoutWrap fxLayoutAlign="start center" matTooltip="Click to copy" matTooltipPosition="after" ngxClipboard [cbContent]="selected?.address" (click)="copyToClipBoard()">
-          <div *ngFor="let word of selected?.readable" class="address-word" fxFlex="11.111">
-            {{ word }}
-          </div>
-        </div>
-  
-        <p class="widget-help" *ngIf="getAddressType() === 'public'">
-          This is your public address &ndash; its balance and transaction history is publicly visible on blockchain. If you would like to increase your privacy, use Private address instead.
-        </p>
-        <p class="widget-help" *ngIf="getAddressType() === 'private'">
-          This is your private address &ndash; its balance and transaction history is hidden for public on blockchain. For auditable addresses, use Public addresses instead.
-        </p>
-  
-      </div><!-- .main -->
-    </div><!-- .address-info -->
-
+    <detail-address [selected]="selected" [type]="type" [unUsedAddress]="unUsedAddress" (rpcLabelUpdate)="rpcLabelUpdate($event)"></detail-address>
     <div class="buttons" fxLayout fxLayoutAlign="space-between center">
       <div class="left" fxFlex="30%">
         <button mat-button color="primary" matTooltip="Generate fresh address" (click)="generateAddress()">
@@ -138,7 +85,7 @@
 
 
   <!-- Address list -->
-  <div class="with-filter" *ngIf="getUnusedAddress()">
+  <div class="with-filter" *ngIf="unUsedAddress">
 
     <div class="no-results" *ngIf="(getSinglePage().length === 0) && (inSearchMode() === true)">
       No addresses found

--- a/src/app/wallet/wallet/receive/receive.component.html
+++ b/src/app/wallet/wallet/receive/receive.component.html
@@ -109,10 +109,9 @@
 
 
   <div class="show-old">
-    <!-- <mat-icon fontSet="partIcon" fontIcon="part-triangle-down"></mat-icon>
-    Show older addresses -->
     <button mat-button class="small" (click)="toggleAddresses()" matTooltip="Display and filter your previously used addresses">
-      <mat-icon fontSet="partIcon" fontIcon="part-triangle-down"></mat-icon>
+      <mat-icon fontSet="partIcon" fontIcon="part-triangle-down" *ngIf="!showOldAddress"></mat-icon>
+      <mat-icon fontSet="partIcon" fontIcon="part-triangle-up" *ngIf="showOldAddress"></mat-icon>
       {{ showOldAddress? "Hide older addresses" : "Show older addresses" }}
     </button>
   </div>
@@ -155,7 +154,7 @@
     </div>
 
     <div *ngIf="getSinglePage().length" class="list-data">
-      <div mat-subheader class="address-title">Used addresses</div>
+      <div class="address-title">Used addresses</div>
       <div *ngFor="let address of getSinglePage()">
 
         <mat-card class="address-info">

--- a/src/app/wallet/wallet/receive/receive.component.html
+++ b/src/app/wallet/wallet/receive/receive.component.html
@@ -23,7 +23,9 @@
 <div  class="container-flex with-tab-bar">
 
   <mat-card class="receive-address">
-    <detail-address [selected]="selected" [type]="type" (rpcLabelUpdate)="rpcLabelUpdate($event)"></detail-address>
+    <div class="address-details">
+      <detail-address [selected]="selected" [type]="type" (rpcLabelUpdate)="rpcLabelUpdate($event)"></detail-address>
+    </div>
     <div class="buttons" fxLayout fxLayoutAlign="space-between center">
       <div class="left" fxFlex="30%">
         <button mat-button color="primary" matTooltip="Generate fresh address" (click)="generateAddress()">

--- a/src/app/wallet/wallet/receive/receive.component.html
+++ b/src/app/wallet/wallet/receive/receive.component.html
@@ -44,7 +44,6 @@
   
         <!-- Address label -->
         <div class="address-label">
-
           <!--
             FIXME/TODO:
               1. default state: disabled input + "edit label" icon (pen-1)
@@ -54,20 +53,12 @@
               4. remove `add-address-label` component/modal
               5. new addresses will be created with default label as "address #51" (according to their {{ address.id }})
           -->
-
           <mat-form-field class="icon-input label-input full-width">
             <input matInput class="label" type="text" value="{{ selected?.label }}" [ngClass]="{'no-label': selected?.label === '(No label)'}" [disabled]="addressInput" [(ngModel)]="label" (keyup.enter)="updateLabel(getUnusedAddress().address)">
-            <!-- TODO: default: -->
             <mat-icon matTooltip="Edit label" *ngIf="addressInput" fontSet="partIcon" fontIcon="part-pen-1" (click)="changeLabel()"></mat-icon>
-            <!-- TODO: show in edit mode: -->
             <mat-icon matTooltip="Save label" *ngIf="!addressInput" fontSet="partIcon" fontIcon="part-circle-check" (click)="updateLabel(getUnusedAddress().address)"></mat-icon>
           </mat-form-field>
-
-          <!--span class="label">{{ selected?.label }}</span>
-          <button mat-button class="small" (click)="openNewAddress(getUnusedAddress().address)" matTooltip="Edit address label" matTooltipPosition="after">
-            <mat-icon fontSet="partIcon" fontIcon="part-pen-1"></mat-icon>
-          </button-->
-        </div>
+        </div><!-- .address-label -->
   
         <!-- Address string -->
         <div class="address address-string" fxLayoutWrap fxLayoutAlign="start center" matTooltip="Click to copy" matTooltipPosition="after" ngxClipboard [cbContent]="selected?.address" (click)="copyToClipBoard()">

--- a/src/app/wallet/wallet/receive/receive.component.html
+++ b/src/app/wallet/wallet/receive/receive.component.html
@@ -98,19 +98,19 @@
       <div *ngFor="let address of getSinglePage()">
 
         <mat-card class="address-info">
-          <div fxFlex="1 1 calc(100% - 79px)">
-            <div fxFlex="0 0 55px" class="address-id">
+
+          <div class="address-name cursor-pointer" (click)="openNewAddress(address)">
+            <div class="address-id">
               /{{ address.id }}
             </div>
-            <div fxFlex="1 1 90%" class="address-name cursor-pointer" (click)="openNewAddress(address)">
-              <span class="address-label" [ngClass]="{'no-label': address.label === '(No label)'}">
-                {{ address.label }}
-              </span>
-              <span class="address">
-                {{ address.address }}
-              </span>
-            </div>
-          </div>
+            <span class="address-label" [ngClass]="{'no-label': address.label === '(No label)'}">
+              {{ address.label }}
+            </span>
+            <span class="address">
+              {{ address.address }}
+            </span>
+          </div><!-- .address-name -->
+
           <div class="address-actions" fxFlex="0 0 50px" fxLayoutAlign="end center">
             <!-- Copy address -->
             <span fxFlex="50%">
@@ -124,8 +124,8 @@
                         (click)="openSignatureModal(address.address)" class="cursor-pointer" ngxClipboard></mat-icon>
             </span>
           </div><!-- .address-actions -->
-        </mat-card>
 
+        </mat-card>
       </div>
     </div><!-- .list-data -->
 

--- a/src/app/wallet/wallet/receive/receive.component.html
+++ b/src/app/wallet/wallet/receive/receive.component.html
@@ -23,7 +23,7 @@
 <div  class="container-flex with-tab-bar">
 
   <mat-card class="receive-address">
-    <detail-address [selected]="selected" [type]="type" [unUsedAddress]="unUsedAddress" (rpcLabelUpdate)="rpcLabelUpdate($event)"></detail-address>
+    <detail-address [selected]="selected" [type]="type" (rpcLabelUpdate)="rpcLabelUpdate($event)"></detail-address>
     <div class="buttons" fxLayout fxLayoutAlign="space-between center">
       <div class="left" fxFlex="30%">
         <button mat-button color="primary" matTooltip="Generate fresh address" (click)="generateAddress()">
@@ -47,7 +47,7 @@
 
 
   <div class="show-old">
-    <button mat-button class="small" (click)="toggleAddresses()" matTooltip="Display and filter your previously used addresses">
+    <button mat-button class="small" (click)="toggleAddresses()" matTooltip="Display and filter your previously used addresses" [disabled]="(getSinglePage().length === 0)">
       <mat-icon fontSet="partIcon" fontIcon="part-triangle-down" *ngIf="!showOldAddress"></mat-icon>
       <mat-icon fontSet="partIcon" fontIcon="part-triangle-up" *ngIf="showOldAddress"></mat-icon>
       {{ showOldAddress? "Hide older addresses" : "Show older addresses" }}
@@ -93,12 +93,12 @@
 
     <div *ngIf="getSinglePage().length" class="list-data">
       <div class="address-title">Used addresses</div>
-      <div *ngFor="let address of getSinglePage()">
+      <div *ngFor="let address of getSinglePage()" (click)="openNewAddress(address)">
 
         <mat-card class="address-info">
           <div fxFlex="100%" fxLayout="row" fxLayoutAlign="center center" fxLayoutGap="10px" layout-padding>
             <div fxFlex="0 0 45px" class="address-id">/{{ address.id }}</div>
-            <div fxFlex="1 1 20%" class="address-label cursor-pointer" [ngClass]="{'no-label': address.label === '(No label)'}" (click)="openNewAddress(address.address)" matTooltip="Edit label" matTooltipPosition="before">
+            <div fxFlex="1 1 20%" class="address-label cursor-pointer" [ngClass]="{'no-label': address.label === '(No label)'}" matTooltip="Edit label" matTooltipPosition="before">
               {{ address.label }}
             </div>
             <div fxFlex="1 1 80%" fxFlex.lt-md="40px" class="address enable-select">

--- a/src/app/wallet/wallet/receive/receive.component.scss
+++ b/src/app/wallet/wallet/receive/receive.component.scss
@@ -111,29 +111,45 @@ mat-card.receive-address {
   margin-top: 0;
 }
 
-.address-info { // address "card"
+mat-card.address-info { // address "card"
   margin-bottom: 12px;
+  padding: 0 24px 0 32px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   .address-id {
     color: $text-muted;
+    margin-top: 24px;
   }
-  .address-label {
-    text-transform: uppercase;
-    font-weight: 700;
-    white-space: nowrap;
+  .address-name { // label + string
     text-overflow: ellipsis;
     overflow: hidden;
-    &.no-label { // unlabeled address
-      font-style: italic;
+    padding: 24px 0;
+    .address-label {
+      font-size: 14px;
       font-weight: 500;
-      opacity: 0.75;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      margin: 0 0 4px 0;
+      display: block;
+      &.no-label { // unlabeled address
+        font-style: italic;
+        font-weight: 500;
+        opacity: 0.75;
+      }
+    }
+    .address { // address string
+      @extend %tfx;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      font-family: monospace;
+      color: $text-muted;
+      background: transparent;
+      transition: background .3s;
     }
   }
-  .address {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    font-family: monospace;
-    color: $text-muted;
-    background: transparent;
-    transition: background .3s;
+  .address-actions {
+    margin-left: 24px;
   }
 }

--- a/src/app/wallet/wallet/receive/receive.component.scss
+++ b/src/app/wallet/wallet/receive/receive.component.scss
@@ -113,7 +113,7 @@ mat-card.receive-address {
   transform: translateX(-50%);
   .mat-icon {
     position: relative;
-    top: 2px;
+    top: 0;
     font-size: 13px;
     margin-right: 3px;
   }

--- a/src/app/wallet/wallet/receive/receive.component.scss
+++ b/src/app/wallet/wallet/receive/receive.component.scss
@@ -19,74 +19,14 @@
 
 // fresh unused receive address
 mat-card.receive-address {
-  width: 720px;
+  width: 745px;
   margin: auto;
   padding: 24px 0 0;
-
-  .address-info {
+  .address-details {
     padding: 0 24px;
   }
 
-  .main {
-    padding-left: 35px;
-
-    .address-type {
-      text-transform: uppercase;
-      color: $text-muted;
-      .mat-icon {
-        margin-right: 4px;
-        position: relative;
-        top: 3px;
-        color: lighten($text-muted, 20%);
-      }
-    }
-
-    .address-label {
-      font-size: 20px;
-      text-transform: none;
-      margin: 0;
-      padding-right: 40px;
-      text-overflow: initial;
-      overflow: visible;
-      .label-input {
-        .mat-icon {
-          right: -36px;
-          top: 10px;
-          &.part-circle-check {
-            color: $color;
-          }
-        }
-      }
-      .label {
-        display: inline-block;
-        height: 23px;
-        font-weight: 500;
-        &:disabled {
-          color: lighten($text, 15%);
-        }
-        &.no-label { // unlabeled address
-          font-style: italic;
-        }
-      }
-    }
-
-    .address-string {
-      @extend %enable-select;
-      font-size: 15px;
-      line-height: 1.45;
-      color: darken($color, 7%);
-      background: rgba($color, 0.04);
-      padding: 7px 14px;
-      margin-bottom: 18px;
-      cursor: pointer;
-    }
-
-    p.widget-help {
-      margin-bottom: 0;
-    }
-
-  }
-
+  // address' action buttons
   .buttons {
     width: 100%;
     margin: 24px 0 0;

--- a/src/app/wallet/wallet/receive/receive.component.scss
+++ b/src/app/wallet/wallet/receive/receive.component.scss
@@ -113,26 +113,31 @@ mat-card.receive-address {
 
 mat-card.address-info { // address "card"
   margin-bottom: 12px;
-  padding: 0 24px 0 32px;
+  padding: 0 24px 0 0;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  .address-id {
-    color: $text-muted;
-    margin-top: 24px;
-  }
   .address-name { // label + string
+    @extend %tfx;
     text-overflow: ellipsis;
     overflow: hidden;
-    padding: 24px 0;
+    padding: 24px 0 24px 32px;
+    display: flex;
+    width: 100%;
+    &:hover {
+      box-shadow: 4px 0 $color inset;
+    }
+    .address-id {
+      color: $text-muted;
+      flex: 0 0 50px;
+    }
     .address-label {
       font-size: 14px;
       font-weight: 500;
       white-space: nowrap;
       text-overflow: ellipsis;
       overflow: hidden;
-      margin: 0 0 4px 0;
-      display: block;
+      margin: -1px 12px 0 0;
       &.no-label { // unlabeled address
         font-style: italic;
         font-weight: 500;
@@ -145,8 +150,11 @@ mat-card.address-info { // address "card"
       text-overflow: ellipsis;
       font-family: monospace;
       color: $text-muted;
-      background: transparent;
-      transition: background .3s;
+      max-width: 350px;
+      margin: 1px 0 0 0;
+      @include break(l) {
+        max-width: 450px;
+      }
     }
   }
   .address-actions {

--- a/src/app/wallet/wallet/receive/receive.component.spec.ts
+++ b/src/app/wallet/wallet/receive/receive.component.spec.ts
@@ -9,6 +9,7 @@ import { ModalsModule } from '../../../modals/modals.module';
 import { SharedModule } from '../../shared/shared.module';  // is this even needed?
 
 import { ReceiveComponent } from './receive.component';
+import { DetailAddressComponent } from './../shared/detail-address/detail-address.component';
 
 describe('ReceiveComponent', () => {
   let component: ReceiveComponent;
@@ -16,7 +17,7 @@ describe('ReceiveComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ ReceiveComponent ],
+      declarations: [ ReceiveComponent, DetailAddressComponent ],
       imports: [
         /* deps */
         QRCodeModule,

--- a/src/app/wallet/wallet/receive/receive.component.ts
+++ b/src/app/wallet/wallet/receive/receive.component.ts
@@ -7,6 +7,7 @@ import { ModalsHelperService } from 'app/modals/modals.module';
 
 import { AddAddressLabelComponent } from './modals/add-address-label/add-address-label.component';
 import { SignatureAddressModalComponent } from '../shared/signature-address-modal/signature-address-modal.component';
+import { QrCodeModalComponent} from '../shared/qr-code-modal/qr-code-modal.component';
 
 import { SnackbarService } from '../../../core/snackbar/snackbar.service';
 
@@ -162,6 +163,7 @@ export class ReceiveComponent implements OnInit {
 
   changeTab(tab: number): void {
     this.page = 1;
+    this.showOldAddress = false;
     if (tab) {
       this.setAddressType('private');
     } else {
@@ -183,13 +185,16 @@ export class ReceiveComponent implements OnInit {
   /**
    * Opens a dialog when creating a new address.
    */
-  openNewAddress(address?: string): void {
-    const dialogRef = this.dialog.open(AddAddressLabelComponent);
+  openNewAddress(address?: object): void {
+    const dialogRef = this.dialog.open(QrCodeModalComponent);
     dialogRef.componentInstance.type = this.type;
-    dialogRef.componentInstance.address = address ? address : '';
+    dialogRef.componentInstance.singleAddress = address;
 
     // update receive page after adding address
-    dialogRef.componentInstance.onAddressAdd.subscribe(result => this.rpc_update());
+    dialogRef.componentInstance.onConfirm.subscribe((msg: string) => {
+      this.flashNotificationService.open(msg);
+      this.rpc_update();
+    });
   }
 
   selectInput(): void {

--- a/src/app/wallet/wallet/receive/receive.component.ts
+++ b/src/app/wallet/wallet/receive/receive.component.ts
@@ -289,7 +289,8 @@ export class ReceiveComponent implements OnInit {
       label: '(No label)',
       address: 'Empty address',
       balance: 0,
-      readable: ['Empty']
+      readable: ['Empty'],
+      owned: false
     };
 
     tempAddress.address = response.address;
@@ -298,6 +299,7 @@ export class ReceiveComponent implements OnInit {
     }
 
     tempAddress.readable = tempAddress.address.match(/.{1,4}/g);
+    tempAddress.owned = response.owned;
 
     if (type === 'public') {
 

--- a/src/app/wallet/wallet/receive/receive.component.ts
+++ b/src/app/wallet/wallet/receive/receive.component.ts
@@ -28,8 +28,6 @@ export class ReceiveComponent implements OnInit {
   /* UI State */
   public type: string = 'public';
   public query: string = '';
-  public addressInput: boolean = true;
-  public label: string = '';
   public address: string = '';
   testnet: boolean = false;
   initialized: boolean = false; /* true => checkUnusedAddress is already looping */
@@ -102,7 +100,7 @@ export class ReceiveComponent implements OnInit {
   }
 
   /** Returns the unused addresses to display in the UI. */
-  getUnusedAddress(): Object {
+  get unUsedAddress(): Object {
     return this.addresses[this.type][0];
   }
 
@@ -374,11 +372,6 @@ export class ReceiveComponent implements OnInit {
     }
   }
 
-  updateLabel(address: string) {
-    this.address = address
-    this.modals.unlock({timeout: 3}, (status) => this.editLabel());
-  }
-
   generateAddress(): void {
     this.modals.unlock({timeout: 3}, (status) => this.newAddress());
   }
@@ -390,30 +383,20 @@ export class ReceiveComponent implements OnInit {
     this.rpcCallAndNotify(call, callParams, msg);
   }
 
-  editLabel(): void {
-    const call = 'manageaddressbook';
-    const callParams = ['newsend', this.address, this.label];
-    const msg = `Label for ${this.address} updated`;
-    this.rpcCallAndNotify(call, callParams, msg);
-  }
-
-  changeLabel(): void {
-    this.addressInput = !this.addressInput
-    if (this.selected.label === '(No label)') {
-      this.selected.label = '';
-    }
-  }
-
   rpcCallAndNotify(call: string, callParams: any, msg: string): void {
     if (call) {
       this.rpc.call(call, callParams)
         .subscribe(response => {
           this.log.d(call, `addNewLabel: successfully executed ${call} ${callParams}`);
           this.flashNotificationService.open(msg)
-          this.addressInput = true;
           this.rpc_update();
         });
     }
+  }
+
+  rpcLabelUpdate(msg: string): void {
+    this.flashNotificationService.open(msg)
+    this.rpc_update();
   }
 
 }

--- a/src/app/wallet/wallet/send/send.component.html
+++ b/src/app/wallet/wallet/send/send.component.html
@@ -1,6 +1,7 @@
 <app-header>
-  <div class="tab-bar">
-    <mat-tab-group (selectChange)="selectTab($event.index)">
+  <div class="tab-bar" fxLayout fxLayoutAlign="space-between stretch">
+
+    <mat-tab-group (selectChange)="selectTab($event.index)" fxFlex="1 1 100%">
       <mat-tab>
         <ng-template mat-tab-label>
           <mat-icon fontSet="partIcon" fontIcon="part-send"></mat-icon>
@@ -14,116 +15,119 @@
         </ng-template>
       </mat-tab>
     </mat-tab-group>
-  </div>
+
+    <div class="buttons">
+      <button mat-button (click)="advanced = !advanced" class="small advanced-options">
+        <mat-icon fontSet="partIcon" fontIcon="{{ (advanced) ? 'part-circle-minus': 'part-circle-plus' }}"></mat-icon>
+        <span>Advanced options</span>
+      </button>
+    </div>
+
+  </div><!-- .tab-bar -->
 </app-header>
 
 
 <div class="container-block with-tab-bar" fxLayout="row" fxLayoutGap="35px">
 
   <div class="from-box" fxFlex="0 0 320px">
-    <mat-card>
-      <div class="title">Pay from</div>
-
-      <!-- Select "FROM" balance/account -->
-      <mat-radio-group class="from-balance-type block-radio" name="sendInput" [(ngModel)]="send.input" 
-                       fxLayout="column" fxLayoutGap="10px" (change)="updateAmount()">
-        <mat-radio-button class="balance" value="part" checked="checked" color="primary"
-                          (click)="send.output = (type === 'sendPayment')? 'part': 'blind'" fxFlex>
-          <div class="name">Public</div>
-          <div class="desc">Available balance:<span class="amount">{{ getBalance('part') }}</span></div>
-        </mat-radio-button>
-        <mat-radio-button class="balance" value="blind" fxFlex color="primary" (click)="send.output = 'part'">
-          <div class="name">Blind</div>
-          <div class="desc">Available balance:<span *ngIf="!checkBalance('blind')" class="amount">{{ getBalance('blind') }}</span>
-            <mat-icon *ngIf="checkBalance('blind')" fontSet="partIcon" fontIcon="part-circle-question" class="help-icon"
-                      matTooltip="It is normal to have a very small balance in Blind even after transferring out everything. This is due to the way CT works and part of the privacy platform."></mat-icon>
-          </div>
-        </mat-radio-button>
-        <mat-radio-button *ngIf="testnet" class="balance" value="anon" color="primary" (click)="send.output = 'part'" fxFlex>
-          <div class="name">Anon</div>
-          <div class="desc">Available balance:<span class="amount">{{ getBalance('anon') }}</span></div>
-        </mat-radio-button>
-      </mat-radio-group><!-- .from-balance-type -->
-
-      <!-- TX info help -->
-      <p class="widget-help" *ngIf="send.input === 'part'">
-        In public transactions, everything is visible on the blockchain &ndash; transaction amount, sender and receiver addresses.
-      </p>
-      <p class="widget-help" *ngIf="send.input === 'blind'">
-        Blinded transactions hide transaction amounts, but the sender and receiver addresses are still visible.
-      </p>
-      <p class="widget-help" *ngIf="send.input === 'anon'">
-        Anon transaction offer the highest privacy &ndash; transaction amounts and not even sender and receiver
-        addresses are publicly visible. The higher privacy level is, the larger fee needs to be paid. Advanced users can further adjust the number of ring signatures.
-      </p>
-
-      <!-- Show privacy slider if anonymous TX -->
-      <div *ngIf="send.input === 'anon' && advanced" class="advanced">
-        <div class="subtitle">Privacy level <small>(no. of ring sigs)</small></div>
-        <div class="privacy-level">
-          <div class="privacy-labels" fxLayout="row" fxLayoutAlign="space-between center">
-            <span
-              fxFlex="0 0 50px"
-              class="privacy-label low"
-              (click)="setPrivacy(4)"
-              matTooltip="Set low privacy"
-              matTooltipPosition="below">Low
-            </span>
-
-            <span
-              fxFlex="0 0 50px"
-              class="privacy-label high"
-              (click)="setPrivacy(16)"
-              matTooltip="Set high privacy"
-              matTooltipPosition="below">High
-            </span>
-
-            <span
-              fxFlex="0 0 50px"
-              class="privacy-label highest"
-              (click)="setPrivacy(32)"
-              matTooltip="Set highest privacy"
-              matTooltipPosition="below">Highest
-            </span>
-          </div><!-- .privacy-labels -->
-
-          <mat-slider
-            thumbLabel
-            color="primary"
-            [min]="3"
-            (change)="onSlide($event)"
-            [max]="32"
-            [value]="send.ringsize">
-          </mat-slider>
-
-          <!-- set default value after clicking the button (8 signatures?) -->
-          <button
-            (click)="setPrivacy(8)"
-            mat-button
-            class="small"
-            matTooltip="Set default, recommended privacy level">
-            <mat-icon fontSet="partIcon" fontIcon="part-anon"></mat-icon>
-            Auto privacy
-          </button>
-        </div><!-- .privacy-level -->
-      </div><!-- /if Anon -->
-    </mat-card>
+    <div class="sticky">
+      <div class="section-title">Pay from</div>
+      <mat-card>
+        <!-- Select "FROM" balance/account -->
+        <mat-radio-group class="from-balance-type block-radio" name="sendInput" [(ngModel)]="send.input" 
+                          fxLayout="column" fxLayoutGap="10px" (change)="updateAmount()">
+          <mat-radio-button class="balance" value="part" checked="checked" color="primary"
+                            (click)="send.output = (type === 'sendPayment')? 'part': 'blind'" fxFlex>
+            <div class="name">Public</div>
+            <div class="desc">Available balance:<span class="amount">{{ getBalance('part') }}</span></div>
+          </mat-radio-button>
+          <mat-radio-button class="balance" value="blind" fxFlex color="primary" (click)="send.output = 'part'">
+            <div class="name">Blind</div>
+            <div class="desc">Available balance:<span *ngIf="!checkBalance('blind')" class="amount">{{ getBalance('blind') }}</span>
+              <mat-icon *ngIf="checkBalance('blind')" fontSet="partIcon" fontIcon="part-circle-question" class="help-icon"
+                        matTooltip="It is normal to have a very small balance in Blind even after transferring out everything. This is due to the way CT works and part of the privacy platform."></mat-icon>
+            </div>
+          </mat-radio-button>
+          <mat-radio-button *ngIf="testnet" class="balance" value="anon" color="primary" (click)="send.output = 'part'" fxFlex>
+            <div class="name">Anon</div>
+            <div class="desc">Available balance:<span class="amount">{{ getBalance('anon') }}</span></div>
+          </mat-radio-button>
+        </mat-radio-group><!-- .from-balance-type -->
+  
+        <!-- TX info help -->
+        <p class="widget-help" *ngIf="send.input === 'part'">
+          In public transactions, everything is visible on the blockchain &ndash; transaction amount, sender and receiver addresses.
+        </p>
+        <p class="widget-help" *ngIf="send.input === 'blind'">
+          Blinded transactions hide transaction amounts, but the sender and receiver addresses are still visible.
+        </p>
+        <p class="widget-help" *ngIf="send.input === 'anon'">
+          Anon transaction offer the highest privacy &ndash; transaction amounts and not even sender and receiver
+          addresses are publicly visible. The higher privacy level is, the larger fee needs to be paid. Advanced users can further adjust the number of ring signatures.
+        </p>
+  
+        <!-- Show privacy slider if anonymous TX -->
+        <div *ngIf="send.input === 'anon' && advanced" class="advanced">
+          <div class="subtitle">Privacy level <small>(no. of ring sigs)</small></div>
+          <div class="privacy-level">
+            <div class="privacy-labels" fxLayout="row" fxLayoutAlign="space-between center">
+              <span
+                fxFlex="0 0 50px"
+                class="privacy-label low"
+                (click)="setPrivacy(4)"
+                matTooltip="Set low privacy"
+                matTooltipPosition="below">Low
+              </span>
+              <span
+                fxFlex="0 0 50px"
+                class="privacy-label high"
+                (click)="setPrivacy(16)"
+                matTooltip="Set high privacy"
+                matTooltipPosition="below">High
+              </span>
+              <span
+                fxFlex="0 0 50px"
+                class="privacy-label highest"
+                (click)="setPrivacy(32)"
+                matTooltip="Set highest privacy"
+                matTooltipPosition="below">Highest
+              </span>
+            </div><!-- .privacy-labels -->
+  
+            <mat-slider
+              thumbLabel
+              color="primary"
+              [min]="3"
+              (change)="onSlide($event)"
+              [max]="32"
+              [value]="send.ringsize">
+            </mat-slider>
+  
+            <!-- set default value after clicking the button (8 signatures?) -->
+            <button
+              (click)="setPrivacy(8)"
+              mat-button
+              class="small"
+              matTooltip="Set default, recommended privacy level">
+              <mat-icon fontSet="partIcon" fontIcon="part-anon"></mat-icon>
+              Auto privacy
+            </button>
+          </div><!-- .privacy-level -->
+        </div><!-- /if Anon -->
+      </mat-card>
+    </div>
   </div><!-- .from-box -->
+
 
 
   <div class="to-box" fxFlex="1 1 100%">
     <form name="walletSendForm">
 
       <!-- Select "TO" balance/account (ONLY for Balance transfer) -->
+      <div class="section-title" *ngIf="type === 'balanceTransfer'">
+        Convert to
+      </div>
       <mat-card class="section to-balance-type" *ngIf="type === 'balanceTransfer'">
-        <div class="title">
-          Convert to
-          <button mat-button (click)="advanced = !advanced" class="small advanced-options">
-            <mat-icon fontSet="partIcon"
-                      fontIcon="{{ (advanced) ? 'part-circle-minus': 'part-circle-plus' }}"></mat-icon>
-            <span>Advanced options</span>
-          </button>
-        </div>
         <mat-radio-group class="to-balance-type block-radio" name="sendOutput" [(ngModel)]="send.output"
                          fxLayout="column" fxLayoutGap="10px" (change)="updateAmount()">
           <mat-radio-button class="balance" value="part" color="primary" (click)="send.input = 'blind'" checked="checked" fxFlex>
@@ -149,16 +153,11 @@
         </p>
       </mat-card>
 
+
+      <div class="section-title" *ngIf="type === 'sendPayment' || advanced">
+        Pay to
+      </div>
       <mat-card class="pay-to" *ngIf="type === 'sendPayment' || advanced">
-        <div class="title">
-          Pay to
-          <button mat-button (click)="advanced = !advanced" *ngIf="type === 'sendPayment'"
-                  class="small advanced-options">
-            <mat-icon fontSet="partIcon"
-                      fontIcon="{{ (advanced) ? 'part-circle-minus': 'part-circle-plus' }}"></mat-icon>
-            <span>Advanced options</span>
-          </button>
-        </div>
 
         <!-- Receiver's address/label -->
         <div class="section receiver-address">
@@ -199,9 +198,7 @@
             <mat-hint align="end">{{narration.value.length}} / 24</mat-hint>
           </mat-form-field>
           <p class="widget-help">
-            Send a short note with your payment. Keep in mind that when sending to Public addresses, the narrations will
-            be recorded and publicly visible on the blockchain. Blind & Anon transactions make narrations visible only
-            for Sender and Receiver.
+            Send a short note with your payment. Keep in mind that when sending to Public addresses, the narrations will be recorded and publicly visible on the blockchain. Blind & Anon transactions make narrations visible only for Sender and Receiver.
           </p>
         </div><!-- .narration.section -->
       </mat-card><!-- .pay-to -->

--- a/src/app/wallet/wallet/send/send.component.scss
+++ b/src/app/wallet/wallet/send/send.component.scss
@@ -15,17 +15,8 @@
   margin-bottom: 20px;
 }
 
-.title { // box titles
-  text-transform: uppercase;
-  font-weight: bold;
-  font-size: 13px;
-  margin: -4px 0 16px !important;
-  .advanced-options {
-    float: right;
-    position: relative;
-    top: -5px;
-    right: -13px;
-  }
+.section-title { // "Pay from/to, Convert" etc.
+  @extend %subtitle;
 }
 
 .subtitle { // subtitles (eg. "privacy level" in anon
@@ -89,7 +80,18 @@
 
 // ------ LAYOUT ------ //
 
-.from-box {
+.container-block {
+  padding-top: 0; // offset subtitles
+}
+
+.from-box { // "pay from.."
+  .sticky {
+    position: sticky;
+    top: $header-main-height + $tab-bar-height + 30px;
+  }
+  mat-card {
+    padding-top: 14px;
+  }
   .advanced {
     background: mix($bg, $color-white);
     border-top: 1px dashed darken($bg, 7%);
@@ -126,7 +128,10 @@
   .widget-help {
     margin-top: 0;
   }
+}
 
+mat-card.to-balance-type { // "convert to.."
+  padding-top: 14px;
 }
 
 .actions {

--- a/src/app/wallet/wallet/shared/address-table/address-table.component.html
+++ b/src/app/wallet/wallet/shared/address-table/address-table.component.html
@@ -17,35 +17,19 @@
   </div>
 
   <mat-list class="list-data">
+
     <div class="no-results" *ngIf="getSinglePage().length === 0">
       No matching addresses found
     </div>
-    <div *ngFor="let address of getSinglePage()" (click)="openQrCodeModal(address)">
 
+    <div *ngFor="let address of getSinglePage()">
       <mat-card class="address-entry">
 
-        <!-- Label -->
-        <div class="label cursor-pointer" *ngIf="displayLabel" matTooltip="Edit Address label" matTooltipPosition="before">
-          {{ address.label }}
+        <!-- label & address string -->
+        <div class="address-name" (click)="openQrCodeModal(address)">
+          <span class="label" *ngIf="displayLabel">{{ address.label }}</span>
+          <span class="address-string" *ngIf="displayAddress">{{ address.address }}</span>
         </div>
-
-        <!-- Address -->
-        <div class="address" *ngIf="displayAddress" matTooltip="Show Address" matTooltipPosition="above">
-          <!--mat-icon *ngIf="!displayQrMenu" class="qr-icon" fontSet="partIcon" fontIcon="part-qr"></mat-icon-->
-          <span class="address-string enable-select">{{ address.address }}</span>
-        </div>
-
-        <!-- Pubkey -->
-        <!--div fxFlex="25" class="grid-cell" *ngIf="displayPublicKey">
-          <span class="title">Public Key</span>
-          <span class="pubkey enable-select">{{ address.publicKey }}</span>
-        </div-->
-
-        <!-- Type -->
-        <!--div fxFlex="25" clas="grid-cell" *ngIf="displayType">
-          <span class="title">Type</span>
-          <span class="type">{{ address.type }}</span>
-        </div-->
 
         <!-- Actions/controls -->
         <div *ngIf="displayToolsMenu" class="address-actions">

--- a/src/app/wallet/wallet/shared/address-table/address-table.component.html
+++ b/src/app/wallet/wallet/shared/address-table/address-table.component.html
@@ -20,18 +20,17 @@
     <div class="no-results" *ngIf="getSinglePage().length === 0">
       No matching addresses found
     </div>
-    <div *ngFor="let address of getSinglePage()">
+    <div *ngFor="let address of getSinglePage()" (click)="openQrCodeModal(address)">
 
       <mat-card class="address-entry">
 
         <!-- Label -->
-        <div class="label cursor-pointer" *ngIf="displayLabel" (click)="editLabel(address.address)" matTooltip="Edit Address label" matTooltipPosition="before">
+        <div class="label cursor-pointer" *ngIf="displayLabel" matTooltip="Edit Address label" matTooltipPosition="before">
           {{ address.label }}
         </div>
 
         <!-- Address -->
-        <div class="address" *ngIf="displayAddress" (click)="openQrCodeModal(address)"
-              matTooltip="Show Address" matTooltipPosition="above">
+        <div class="address" *ngIf="displayAddress" matTooltip="Show Address" matTooltipPosition="above">
           <!--mat-icon *ngIf="!displayQrMenu" class="qr-icon" fontSet="partIcon" fontIcon="part-qr"></mat-icon-->
           <span class="address-string enable-select">{{ address.address }}</span>
         </div>

--- a/src/app/wallet/wallet/shared/address-table/address-table.component.scss
+++ b/src/app/wallet/wallet/shared/address-table/address-table.component.scss
@@ -8,28 +8,41 @@ mat-card.address-entry {
   display: flex;
   justify-content: space-between;
   margin-bottom: 12px;
-  padding-left: 0;
+  padding: 0 24px 0 0;
   & > div {
     margin: 0 20px 0 0;
   }
   .address-name {
+    @extend %tfx;
     flex: 1 0 calc(100% - 180px);
-    padding-left: 24px;
+    padding: 24px 0 24px 24px;
     text-overflow: ellipsis;
     overflow: hidden;
+    display: flex;
+    width: 100%;
     cursor: pointer;
+    &:hover {
+      box-shadow: 4px 0 $color inset;
+    }
     .label {
       font-size: 14px;
       font-weight: 500;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      margin: 0 0 4px 0;
+      margin: -1px 12px 0 0;
       display: block;
     }
     .address-string {
       font-family: monospace;
       color: $text-muted;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 350px;
+      margin: 1px 0 0 0;
+      @include break(l) {
+        max-width: 450px;
+      }
     }
   }
   

--- a/src/app/wallet/wallet/shared/address-table/address-table.component.scss
+++ b/src/app/wallet/wallet/shared/address-table/address-table.component.scss
@@ -5,39 +5,31 @@
 }
 
 mat-card.address-entry {
-  margin-bottom: 12px;
   display: flex;
   justify-content: space-between;
+  margin-bottom: 12px;
+  padding-left: 0;
   & > div {
     margin: 0 20px 0 0;
   }
-  .label {
-    text-transform: uppercase;
-    font-weight: bold;
-    overflow: hidden;
+  .address-name {
+    flex: 1 0 calc(100% - 180px);
+    padding-left: 24px;
     text-overflow: ellipsis;
-    flex: 0 0 200px;
-    @include break(l) {
-      flex: 0 0 300px;
+    overflow: hidden;
+    cursor: pointer;
+    .label {
+      font-size: 14px;
+      font-weight: 500;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      margin: 0 0 4px 0;
+      display: block;
     }
-  }
-  
-  .address {
-    flex: 1 1 200px;
-    /*.qr-icon {
-      position: relative;
-      top: 3px;
-      margin-right: 8px;
-      cursor: pointer;
-    }*/
     .address-string {
-      @extend %tfx;
       font-family: monospace;
       color: $text-muted;
-      cursor: pointer;
-      &:hover {
-        color: darken($color, 3%);
-      }
     }
   }
   
@@ -46,6 +38,7 @@ mat-card.address-entry {
     flex: 0 0 86px;
     display: flex;
     justify-content: space-between;
+    align-items: center;
   }
 }
 

--- a/src/app/wallet/wallet/shared/address-table/address-table.component.ts
+++ b/src/app/wallet/wallet/shared/address-table/address-table.component.ts
@@ -49,7 +49,8 @@ export class AddressTableComponent implements OnInit, OnChanges {
   public singleAddress: any = {
     label: 'Empty label',
     address: 'Empty address',
-    owned: false
+    owned: false,
+    readable: '',
   };
   // Pagination
   currentPage: number = 1;
@@ -169,10 +170,24 @@ export class AddressTableComponent implements OnInit, OnChanges {
   }
 
   /** Open QR Code Modal */
-  openQrCodeModal(address: Object): void {
+  openQrCodeModal(address: any): void {
     const dialogRef = this.dialog.open(QrCodeModalComponent);
-    dialogRef.componentInstance.singleAddress = address;
+    this.singleAddress = address;
+    // creating readable property to ensure that it has proper address in readable format
+    this.singleAddress.readable = address.address.match(/.{1,4}/g);
+    dialogRef.componentInstance.singleAddress = this.singleAddress;
+    // getting the type of address
+    dialogRef.componentInstance.type = address.address.length < 35 ? 'public' : 'private';
     this.log.d(`qrcode, address: ${JSON.stringify(address)}`);
+
+    dialogRef.componentInstance.onConfirm.subscribe((msg: string) => {
+      if (msg) {
+        this.flashNotification.open(msg);
+        this._addressService.updateAddressList();
+      } else {
+        this.openSignatureModal(address.address);
+      }
+    });
   }
 
   showAddress(address: string) {

--- a/src/app/wallet/wallet/shared/detail-address/detail-address.component.html
+++ b/src/app/wallet/wallet/shared/detail-address/detail-address.component.html
@@ -18,15 +18,6 @@
 
     <!-- Address label -->
     <div class="address-label">
-      <!--
-        FIXME/TODO:
-          1. default state: disabled input + "edit label" icon (pen-1)
-          2. when user clicks on "edit label" icon, input gets enabled + icon switches to "save label"
-          3. when user saves label, input value gets updated, input becomes disabled again + icon switches back to "edit label"
-        =====
-          4. remove `add-address-label` component/modal
-          5. new addresses will be created with default label as "address #51" (according to their {{ address.id }})
-      -->
       <mat-form-field class="icon-input label-input full-width">
         <input matInput class="label" type="text" value="{{ selected?.label }}" [ngClass]="{'no-label': selected?.label === '(No label)'}" [disabled]="isEditableMode" [(ngModel)]="label" (keyup.enter)="updateLabel(unUsedAddress?.address)">
         <mat-icon matTooltip="Edit label" *ngIf="isEditableMode" fontSet="partIcon" fontIcon="part-pen-1" (click)="changeLabel()"></mat-icon>

--- a/src/app/wallet/wallet/shared/detail-address/detail-address.component.html
+++ b/src/app/wallet/wallet/shared/detail-address/detail-address.component.html
@@ -1,0 +1,52 @@
+<div class="address-info" fxLayout>
+  <div class="sidebar" fxFlex="0 0 180px">
+    <!-- QR code -->
+    <div #qrCode class="qrcode">
+      <qrcode size="180" [level]="'H'" qrdata="particl:{{ selected?.address }}">
+      </qrcode>
+    </div><!-- qrcode -->
+  </div>
+
+  <div class="main" fxFlex="1 1 480px">
+
+    <!-- Address type (public/private)-->
+    <div class="address-type">
+      <mat-icon *ngIf="type === 'public'" fontSet="partIcon" fontIcon="part-public"></mat-icon>
+      <mat-icon *ngIf="type === 'private'" fontSet="partIcon" fontIcon="part-anon"></mat-icon>
+      {{ type }} address #{{ selected?.id }}
+    </div>
+
+    <!-- Address label -->
+    <div class="address-label">
+      <!--
+        FIXME/TODO:
+          1. default state: disabled input + "edit label" icon (pen-1)
+          2. when user clicks on "edit label" icon, input gets enabled + icon switches to "save label"
+          3. when user saves label, input value gets updated, input becomes disabled again + icon switches back to "edit label"
+        =====
+          4. remove `add-address-label` component/modal
+          5. new addresses will be created with default label as "address #51" (according to their {{ address.id }})
+      -->
+      <mat-form-field class="icon-input label-input full-width">
+        <input matInput class="label" type="text" value="{{ selected?.label }}" [ngClass]="{'no-label': selected?.label === '(No label)'}" [disabled]="isEditableMode" [(ngModel)]="label" (keyup.enter)="updateLabel(unUsedAddress?.address)">
+        <mat-icon matTooltip="Edit label" *ngIf="isEditableMode" fontSet="partIcon" fontIcon="part-pen-1" (click)="changeLabel()"></mat-icon>
+        <mat-icon matTooltip="Save label" *ngIf="!isEditableMode" fontSet="partIcon" fontIcon="part-circle-check" (click)="updateLabel(unUsedAddress?.address)"></mat-icon>
+      </mat-form-field>
+    </div><!-- .address-label -->
+
+    <!-- Address string -->
+    <div class="address address-string" fxLayoutWrap fxLayoutAlign="start center" matTooltip="Click to copy" matTooltipPosition="after" ngxClipboard [cbContent]="selected?.address" (click)="copyToClipBoard()">
+      <div *ngFor="let word of selected?.readable" class="address-word" fxFlex="11.111">
+        {{ word }}
+      </div>
+    </div>
+
+    <p class="widget-help" *ngIf="type === 'public'">
+      This is your public address &ndash; its balance and transaction history is publicly visible on blockchain. If you would like to increase your privacy, use Private address instead.
+    </p>
+    <p class="widget-help" *ngIf="type === 'private'">
+      This is your private address &ndash; its balance and transaction history is hidden for public on blockchain. For auditable addresses, use Public addresses instead.
+    </p>
+
+  </div><!-- .main -->
+</div><!-- .address-info -->

--- a/src/app/wallet/wallet/shared/detail-address/detail-address.component.html
+++ b/src/app/wallet/wallet/shared/detail-address/detail-address.component.html
@@ -19,9 +19,9 @@
     <!-- Address label -->
     <div class="address-label">
       <mat-form-field class="icon-input label-input full-width">
-        <input matInput class="label" type="text" value="{{ selected?.label }}" [ngClass]="{'no-label': selected?.label === '(No label)'}" [disabled]="isEditableMode" [(ngModel)]="label" (keyup.enter)="updateLabel(unUsedAddress?.address)">
+        <input matInput class="label" type="text" value="{{ selected?.label }}" [ngClass]="{'no-label': selected?.label === '(No label)'}" [disabled]="isEditableMode" [(ngModel)]="label" (keyup.enter)="updateLabel(selected?.address)">
         <mat-icon matTooltip="Edit label" *ngIf="isEditableMode" fontSet="partIcon" fontIcon="part-pen-1" (click)="changeLabel()"></mat-icon>
-        <mat-icon matTooltip="Save label" *ngIf="!isEditableMode" fontSet="partIcon" fontIcon="part-circle-check" (click)="updateLabel(unUsedAddress?.address)"></mat-icon>
+        <mat-icon matTooltip="Save label" *ngIf="!isEditableMode" fontSet="partIcon" fontIcon="part-circle-check" (click)="updateLabel(selected?.address)"></mat-icon>
       </mat-form-field>
     </div><!-- .address-label -->
 

--- a/src/app/wallet/wallet/shared/detail-address/detail-address.component.html
+++ b/src/app/wallet/wallet/shared/detail-address/detail-address.component.html
@@ -15,7 +15,7 @@
       <mat-icon *ngIf="type === 'private'" fontSet="partIcon" fontIcon="part-anon"></mat-icon>
       {{ type }} address
       <!-- FIXME: show ID only when MY address: -->
-      #{{ selected?.id }}
+      {{ selected?.owned === 'true' ? '#' + selected?.id : "" }}
     </div>
 
     <!-- Address label -->
@@ -35,19 +35,19 @@
     </div>
 
     <!-- if PUBLIC + MY address: -->
-    <p class="widget-help" *ngIf="type === 'public'">
+    <p class="widget-help" *ngIf="type === 'public' && selected?.owned === 'true' ">
       This is your public address &ndash; its balance and transaction history is publicly visible on blockchain. If you would like to increase your privacy, use Private address instead.
     </p>
     <!-- if PRIVATE + MY address: -->
-    <p class="widget-help" *ngIf="type === 'private'">
+    <p class="widget-help" *ngIf="type === 'private' && selected?.owned === 'true' ">
       This is your private address &ndash; its balance and transaction history is hidden for public on blockchain. For auditable addresses, use Public addresses instead.
     </p>
     <!-- TODO: if PUBLIC + SAVED 3rd-PARTY (not mine) address: -->
-    <p class="widget-help" *ngIf="type === 'public' && xxxx">
+    <p class="widget-help" *ngIf="type === 'public' && selected?.owned === 'false'">
       3rd-party's Public address (not yours) &ndash; any payments made to this address will be publicly visible on the blockchain. For increased privacy, you should ask the recipient for their Private address instead.
     </p>
     <!-- TODO: if PRIVATE + SAVED 3rd-PARTY (not mine) address: -->
-    <p class="widget-help" *ngIf="type === 'private' && xxxx">
+    <p class="widget-help" *ngIf="type === 'private' && selected?.owned === 'false'">
       3rd-party's Private address (not yours) &ndash; any payments made to this address will be hidden for public on the blockchain.
     </p>
 

--- a/src/app/wallet/wallet/shared/detail-address/detail-address.component.html
+++ b/src/app/wallet/wallet/shared/detail-address/detail-address.component.html
@@ -7,13 +7,15 @@
     </div><!-- qrcode -->
   </div>
 
-  <div class="main" fxFlex="1 1 480px">
+  <div class="address-details" fxFlex="1 1 480px">
 
     <!-- Address type (public/private)-->
     <div class="address-type">
       <mat-icon *ngIf="type === 'public'" fontSet="partIcon" fontIcon="part-public"></mat-icon>
       <mat-icon *ngIf="type === 'private'" fontSet="partIcon" fontIcon="part-anon"></mat-icon>
-      {{ type }} address #{{ selected?.id }}
+      {{ type }} address
+      <!-- FIXME: show ID only when MY address: -->
+      #{{ selected?.id }}
     </div>
 
     <!-- Address label -->
@@ -32,11 +34,21 @@
       </div>
     </div>
 
+    <!-- if PUBLIC + MY address: -->
     <p class="widget-help" *ngIf="type === 'public'">
       This is your public address &ndash; its balance and transaction history is publicly visible on blockchain. If you would like to increase your privacy, use Private address instead.
     </p>
+    <!-- if PRIVATE + MY address: -->
     <p class="widget-help" *ngIf="type === 'private'">
       This is your private address &ndash; its balance and transaction history is hidden for public on blockchain. For auditable addresses, use Public addresses instead.
+    </p>
+    <!-- TODO: if PUBLIC + SAVED 3rd-PARTY (not mine) address: -->
+    <p class="widget-help" *ngIf="type === 'public' && xxxx">
+      3rd-party's Public address (not yours) &ndash; any payments made to this address will be publicly visible on the blockchain. For increased privacy, you should ask the recipient for their Private address instead.
+    </p>
+    <!-- TODO: if PRIVATE + SAVED 3rd-PARTY (not mine) address: -->
+    <p class="widget-help" *ngIf="type === 'private' && xxxx">
+      3rd-party's Private address (not yours) &ndash; any payments made to this address will be hidden for public on the blockchain.
     </p>
 
   </div><!-- .main -->

--- a/src/app/wallet/wallet/shared/detail-address/detail-address.component.scss
+++ b/src/app/wallet/wallet/shared/detail-address/detail-address.component.scss
@@ -1,0 +1,1 @@
+@import "./src/assets/_config"; // import shared colors etc.

--- a/src/app/wallet/wallet/shared/detail-address/detail-address.component.scss
+++ b/src/app/wallet/wallet/shared/detail-address/detail-address.component.scss
@@ -1,1 +1,69 @@
 @import "./src/assets/_config"; // import shared colors etc.
+
+
+// ------ Address details ------ //
+
+.address-info { // container of everything
+  //padding: 0 24px;
+}
+
+.address-details { // content block (type, label, string)
+  margin-left: 30px;
+}
+
+.address-type {
+  text-transform: uppercase;
+  color: $text-muted;
+  .mat-icon {
+    margin-right: 4px;
+    position: relative;
+    top: 3px;
+    color: lighten($text-muted, 20%);
+  }
+}
+
+.address-label {
+  font-size: 20px;
+  text-transform: none;
+  margin: 0;
+  padding-right: 40px;
+  text-overflow: initial;
+  overflow: visible;
+  .label-input {
+    .mat-icon {
+      right: -36px;
+      top: 10px;
+      &.part-circle-check {
+        color: $color;
+      }
+    }
+  }
+  .label {
+    display: inline-block;
+    height: 23px;
+    font-weight: 500;
+    &:disabled {
+      color: lighten($text, 15%);
+    }
+    &.no-label { // unlabeled address
+      font-style: italic;
+    }
+  }
+}
+
+.address-string {
+  @extend %enable-select;
+  font-size: 15px;
+  font-family: monospace;
+  line-height: 1.45;
+  color: darken($color, 7%);
+  background: rgba($color, 0.04);
+  padding: 7px 0 7px 14px; // offset flex-wrap margin
+  margin-bottom: 18px;
+  cursor: pointer;
+}
+
+.widget-help {
+  margin-bottom: 0;
+}
+ 

--- a/src/app/wallet/wallet/shared/detail-address/detail-address.component.scss
+++ b/src/app/wallet/wallet/shared/detail-address/detail-address.component.scss
@@ -3,10 +3,6 @@
 
 // ------ Address details ------ //
 
-.address-info { // container of everything
-  //padding: 0 24px;
-}
-
 .address-details { // content block (type, label, string)
   margin-left: 30px;
 }

--- a/src/app/wallet/wallet/shared/detail-address/detail-address.component.spec.ts
+++ b/src/app/wallet/wallet/shared/detail-address/detail-address.component.spec.ts
@@ -34,13 +34,4 @@ describe('DetailAddressComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
-/*
-  it('should changePage', () => {
-    // component.pageChanged();
-    expect(component.pageChanged).toBeTruthy();
-  });
-*/
-  it('should get addressService', () => {
-    expect(component._addressService).toBeDefined();
-  });
 });

--- a/src/app/wallet/wallet/shared/detail-address/detail-address.component.spec.ts
+++ b/src/app/wallet/wallet/shared/detail-address/detail-address.component.spec.ts
@@ -1,0 +1,46 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SharedModule } from '../../../shared/shared.module';
+import { WalletModule } from '../../../wallet/wallet.module';
+import { CoreModule } from '../../../../core/core.module';
+import { CoreUiModule } from '../../../../core-ui/core-ui.module';
+import { ModalsModule } from '../../../../modals/modals.module';
+
+import { DetailAddressComponent } from './detail-address.component';
+
+describe('DetailAddressComponent', () => {
+  let component: DetailAddressComponent;
+  let fixture: ComponentFixture<DetailAddressComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        SharedModule,  // is this even needed?
+        WalletModule.forRoot(),  // is this even needed?
+        CoreModule.forRoot(),
+        CoreUiModule.forRoot(),
+        ModalsModule.forRoot()
+      ],
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DetailAddressComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+/*
+  it('should changePage', () => {
+    // component.pageChanged();
+    expect(component.pageChanged).toBeTruthy();
+  });
+*/
+  it('should get addressService', () => {
+    expect(component._addressService).toBeDefined();
+  });
+});

--- a/src/app/wallet/wallet/shared/detail-address/detail-address.component.ts
+++ b/src/app/wallet/wallet/shared/detail-address/detail-address.component.ts
@@ -14,7 +14,6 @@ export class DetailAddressComponent implements OnInit {
 
   @Input() selected: any;
   @Input() type: string = 'public';
-  @Input() unUsedAddress: any;
   @Output() rpcLabelUpdate: EventEmitter<any> = new EventEmitter();
 
   isEditableMode: boolean = true;

--- a/src/app/wallet/wallet/shared/detail-address/detail-address.component.ts
+++ b/src/app/wallet/wallet/shared/detail-address/detail-address.component.ts
@@ -1,0 +1,55 @@
+import { Component, OnInit, Input, Output, EventEmitter} from '@angular/core';
+import { Subscription } from 'rxjs/Subscription';
+import { MatDialog } from '@angular/material';
+import { Log } from 'ng2-logger';
+
+import { ModalsHelperService } from 'app/modals/modals.module';
+import { RpcService } from '../../../../core/core.module';
+@Component({
+  selector: 'detail-address',
+  templateUrl: './detail-address.component.html',
+  styleUrls: ['./detail-address.component.scss']
+})
+export class DetailAddressComponent {
+
+  @Input() selected: any;
+  @Input() type: string = 'public';
+  @Input() unUsedAddress: any;
+  @Output() rpcLabelUpdate: EventEmitter = new EventEmitter();
+
+  public label: string = '';
+  isEditableMode: boolean = true;
+  log: any = Log.create('detail-address.component');
+
+  constructor( private modals: ModalsHelperService, private rpc: RpcService) {
+  }
+
+  changeLabel(): void {
+    this.isEditableMode = !this.isEditableMode;
+    if (this.selected.label === '(No label)') {
+      this.selected.label = '';
+    }
+  }
+
+  updateLabel(address: string) {
+    this.modals.unlock({timeout: 3}, (status) => this.editLabel(address));
+  }
+
+  editLabel(address: string): void {
+    const call = 'manageaddressbook';
+    const callParams = ['newsend', address, this.label];
+    const msg = `Label for ${address} updated`;
+    this.rpcCallAndNotify(call, callParams, msg);
+  }
+
+  rpcCallAndNotify(call: string, callParams: any, msg: string): void {
+    if (call) {
+      this.rpc.call(call, callParams)
+        .subscribe(response => {
+          this.log.d(call, `addNewLabel: successfully executed ${call} ${callParams}`);
+          this.isEditableMode = true;
+          this.rpcLabelUpdate.emit(msg)
+        });
+    }
+  }
+}

--- a/src/app/wallet/wallet/shared/detail-address/detail-address.component.ts
+++ b/src/app/wallet/wallet/shared/detail-address/detail-address.component.ts
@@ -15,10 +15,10 @@ export class DetailAddressComponent {
   @Input() selected: any;
   @Input() type: string = 'public';
   @Input() unUsedAddress: any;
-  @Output() rpcLabelUpdate: EventEmitter = new EventEmitter();
+  @Output() rpcLabelUpdate: EventEmitter<any> = new EventEmitter();
 
-  public label: string = '';
   isEditableMode: boolean = true;
+  label: string;
   log: any = Log.create('detail-address.component');
 
   constructor( private modals: ModalsHelperService, private rpc: RpcService) {

--- a/src/app/wallet/wallet/shared/detail-address/detail-address.component.ts
+++ b/src/app/wallet/wallet/shared/detail-address/detail-address.component.ts
@@ -31,7 +31,7 @@ export class DetailAddressComponent implements OnInit, OnChanges {
       this.label = this.selected.label;
     }
   }
-  
+
   ngOnChanges(changes: SimpleChanges) {
     this.isEditableMode = true;
   }

--- a/src/app/wallet/wallet/shared/detail-address/detail-address.component.ts
+++ b/src/app/wallet/wallet/shared/detail-address/detail-address.component.ts
@@ -4,7 +4,7 @@ import { MatDialog } from '@angular/material';
 import { Log } from 'ng2-logger';
 
 import { ModalsHelperService } from 'app/modals/modals.module';
-import { RpcService } from '../../../../core/core.module';
+import { RpcService, SnackbarService } from '../../../../core/core.module';
 @Component({
   selector: 'detail-address',
   templateUrl: './detail-address.component.html',
@@ -20,8 +20,10 @@ export class DetailAddressComponent implements OnInit {
   label: string;
   log: any = Log.create('detail-address.component');
 
-  constructor( private modals: ModalsHelperService, private rpc: RpcService) {
-  }
+  constructor( private modals: ModalsHelperService,
+    private rpc: RpcService,
+    private snackbar: SnackbarService
+  ) {}
 
   ngOnInit(): void {
     // Setting label forcefully
@@ -46,6 +48,10 @@ export class DetailAddressComponent implements OnInit {
     const callParams = ['newsend', address, this.label];
     const msg = `Label for ${address} updated`;
     this.rpcCallAndNotify(call, callParams, msg);
+  }
+
+  copyToClipBoard(): void {
+    this.snackbar.open('Address copied to clipboard', '');
   }
 
   rpcCallAndNotify(call: string, callParams: any, msg: string): void {

--- a/src/app/wallet/wallet/shared/detail-address/detail-address.component.ts
+++ b/src/app/wallet/wallet/shared/detail-address/detail-address.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, Output, EventEmitter} from '@angular/core';
+import { Component, OnInit, OnChanges, Input, Output, EventEmitter, SimpleChanges} from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
 import { MatDialog } from '@angular/material';
 import { Log } from 'ng2-logger';
@@ -10,7 +10,7 @@ import { RpcService, SnackbarService } from '../../../../core/core.module';
   templateUrl: './detail-address.component.html',
   styleUrls: ['./detail-address.component.scss']
 })
-export class DetailAddressComponent implements OnInit {
+export class DetailAddressComponent implements OnInit, OnChanges {
 
   @Input() selected: any;
   @Input() type: string = 'public';
@@ -31,6 +31,11 @@ export class DetailAddressComponent implements OnInit {
       this.label = this.selected.label;
     }
   }
+  
+  ngOnChanges(changes: SimpleChanges) {
+    this.isEditableMode = true;
+  }
+
 
   changeLabel(): void {
     this.isEditableMode = !this.isEditableMode;

--- a/src/app/wallet/wallet/shared/detail-address/detail-address.component.ts
+++ b/src/app/wallet/wallet/shared/detail-address/detail-address.component.ts
@@ -10,7 +10,7 @@ import { RpcService } from '../../../../core/core.module';
   templateUrl: './detail-address.component.html',
   styleUrls: ['./detail-address.component.scss']
 })
-export class DetailAddressComponent {
+export class DetailAddressComponent implements OnInit {
 
   @Input() selected: any;
   @Input() type: string = 'public';
@@ -22,6 +22,13 @@ export class DetailAddressComponent {
   log: any = Log.create('detail-address.component');
 
   constructor( private modals: ModalsHelperService, private rpc: RpcService) {
+  }
+
+  ngOnInit(): void {
+    // Setting label forcefully
+    if (this.selected) {
+      this.label = this.selected.label;
+    }
   }
 
   changeLabel(): void {

--- a/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.html
+++ b/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.html
@@ -10,7 +10,7 @@
 
 <div mat-dialog-content class="dialog-content">
 
-  <detail-address [selected]="singleAddress" [type]="type" [unUsedAddress]="unUsedAddress" (rpcLabelUpdate)="rpcLabelUpdate($event)"></detail-address>
+  <detail-address [selected]="singleAddress" [type]="type" (rpcLabelUpdate)="rpcLabelUpdate($event)"></detail-address>
 </div><!-- .dialog-content -->
 
 

--- a/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.html
+++ b/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.html
@@ -15,7 +15,7 @@
 <mat-dialog-actions fxLayout fxLayoutAlign="space-between center">
   <div class="left">
 
-    <button mat-button class="explorer" (click)="rpcLabelUpdate()">
+    <button mat-button class="explorer">
       <mat-icon fontSet="partIcon" fontIcon="part-person-check"></mat-icon>
       Sign/verify
     </button>

--- a/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.html
+++ b/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.html
@@ -10,62 +10,7 @@
 
 <div mat-dialog-content class="dialog-content">
 
-  <div class="row" fxLayout>
-
-    <div class="qr-code" fxFlex="1 0 180px">
-      <div #qrCode class="card qr">
-        <qrcode [level]="'H'" size="180" qrdata="particl:{{ singleAddress.address }}"></qrcode>
-      </div>
-    </div>
-
-    <div class="address-details" fxFlex="1 1 100%">
-      
-      <!-- Address type (public/private)-->
-      <div class="address-type">
-        <mat-icon *ngIf="type === 'public'" fontSet="partIcon" fontIcon="part-public"></mat-icon>
-        <mat-icon *ngIf="type === 'private'" fontSet="partIcon" fontIcon="part-anon"></mat-icon>
-        {{ type }} address
-      </div>
-
-      <!-- Address label -->
-      <div class="address-label">
-
-        <!-- FIXME: implement displaying/editing of address label -->
-        <mat-form-field class="icon-input label-input full-width">
-          <input matInput class="label" type="text" value="{{ singleAddress.label }}" [ngClass]="{'no-label': singleAddress.label === '(No label)'}" [disabled]="addressInput" [(ngModel)]="label" (keyup.enter)="updateLabel(getUnusedAddress().address)">
-          <mat-icon matTooltip="Edit label" *ngIf="addressInput" fontSet="partIcon" fontIcon="part-pen-1" (click)="changeLabel()"></mat-icon>
-          <mat-icon matTooltip="Save label" *ngIf="!addressInput" fontSet="partIcon" fontIcon="part-circle-check" (click)="updateLabel(getUnusedAddress().address)"></mat-icon>
-        </mat-form-field>
-
-      </div><!-- .address-label -->
-
-      <!-- TODO: implement "click to copy to clipboard" -->
-      <div class="address address-string" fxLayoutWrap fxLayoutAlign="start center" matTooltip="Click to copy" matTooltipPosition="after" ngxClipboard [cbContent]="selected?.address" (click)="copyToClipBoard()">
-        <div *ngFor="let word of showAddress(singleAddress.address)" class="address-word" fxFlex="11.111">
-          {{ word }}
-        </div>
-      </div>
-
-      <!-- TODO: if PUBLIC + MY address: -->
-      <p class="widget-help" *ngIf="type === 'public'">
-        This is your public address &ndash; its balance and transaction history is publicly visible on blockchain. If you would like to increase your privacy, use Private address instead.
-      </p>
-      <!-- TODO: if PRIVATE + MY address: -->
-      <p class="widget-help" *ngIf="type === 'private'">
-        This is your private address &ndash; its balance and transaction history is hidden for public on blockchain. For auditable addresses, use Public addresses instead.
-      </p>
-
-      <!-- TODO: if PUBLIC + SAVED 3rd-PARTY (not mine) address: -->
-      <p class="widget-help" *ngIf="type === 'public' && xxxx">
-        3rd-party's Public address (not yours) &ndash; any payments made to this address will be publicly visible on the blockchain. For increased privacy, you should ask the recipient for their Private address instead.
-      </p>
-      <!-- TODO: if PRIVATE + SAVED 3rd-PARTY (not mine) address: -->
-      <p class="widget-help" *ngIf="type === 'private' && xxxx">
-        3rd-party's Private address (not yours) &ndash; any payments made to this address will be hidden for public on the blockchain.
-      </p>
-
-    </div><!-- .address-details -->
-  </div><!-- .row -->
+  <detail-address [selected]="singleAddress" [type]="type" [unUsedAddress]="unUsedAddress" (rpcLabelUpdate)="rpcLabelUpdate($event)"></detail-address>
 </div><!-- .dialog-content -->
 
 
@@ -73,7 +18,7 @@
   <div class="left">
 
     <!-- FIXME: implement functionality: -->
-    <button mat-button class="explorer">
+    <button mat-button class="explorer" (click)="rpcLabelUpdate()">
       <mat-icon fontSet="partIcon" fontIcon="part-person-check"></mat-icon>
       Sign/verify
     </button>

--- a/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.html
+++ b/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.html
@@ -1,7 +1,6 @@
-<!-- TODO: if SAVED 3rd-PARTY (not mine) address: -->
-<div mat-dialog-title>Saved address details</div>
-<!-- TODO: if MY address: -->
-<div mat-dialog-title *ngIf="">Your used address details</div>
+
+<div mat-dialog-title *ngIf="singleAddress?.owned === 'false'">Saved address details</div>
+<div mat-dialog-title *ngIf="singleAddress?.owned === 'true'">Your used address details</div>
 
 
 <button class="small-close_button pull-right" (click)="dialogClose()">

--- a/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.html
+++ b/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.html
@@ -9,7 +9,6 @@
 </button>
 
 <div mat-dialog-content class="dialog-content">
-
   <detail-address [selected]="singleAddress" [type]="type" (rpcLabelUpdate)="rpcLabelUpdate($event)"></detail-address>
 </div><!-- .dialog-content -->
 
@@ -17,7 +16,6 @@
 <mat-dialog-actions fxLayout fxLayoutAlign="space-between center">
   <div class="left">
 
-    <!-- FIXME: implement functionality: -->
     <button mat-button class="explorer" (click)="rpcLabelUpdate()">
       <mat-icon fontSet="partIcon" fontIcon="part-person-check"></mat-icon>
       Sign/verify

--- a/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.html
+++ b/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.html
@@ -1,4 +1,8 @@
-<div mat-dialog-title>Address details</div>
+<!-- TODO: if SAVED 3rd-PARTY (not mine) address: -->
+<div mat-dialog-title>Saved address details</div>
+<!-- TODO: if MY address: -->
+<div mat-dialog-title *ngIf="">Your used address details</div>
+
 
 <button class="small-close_button pull-right" (click)="dialogClose()">
   <mat-icon fontSet="partIcon" fontIcon="part-circle-remove"></mat-icon>
@@ -8,9 +12,9 @@
 
   <div class="row" fxLayout>
 
-    <div class="qr-code" fxFlex="1 0 200px">
+    <div class="qr-code" fxFlex="1 0 180px">
       <div #qrCode class="card qr">
-        <qrcode [level]="'H'" size="150" qrdata="particl:{{ singleAddress.address }}"></qrcode>
+        <qrcode [level]="'H'" size="180" qrdata="particl:{{ singleAddress.address }}"></qrcode>
       </div>
     </div>
 
@@ -18,23 +22,46 @@
       
       <!-- Address type (public/private)-->
       <div class="address-type">
-        <mat-icon *ngIf="addressType === 'public'" fontSet="partIcon" fontIcon="part-public"></mat-icon>
-        <mat-icon *ngIf="addressType === 'private'" fontSet="partIcon" fontIcon="part-anon"></mat-icon>
-        {{ addressType }} address
+        <mat-icon *ngIf="type === 'public'" fontSet="partIcon" fontIcon="part-public"></mat-icon>
+        <mat-icon *ngIf="type === 'private'" fontSet="partIcon" fontIcon="part-anon"></mat-icon>
+        {{ type }} address
       </div>
 
-      <div class="label">{{ singleAddress.label }}</div>
+      <!-- Address label -->
+      <div class="address-label">
 
-      <div class="address-string">
-        <div class="details-address enable-select" fxLayoutWrap layout-padding>
-          <div *ngFor="let word of showAddress(singleAddress.address)" class="address-word" fxFlex="33">
-            {{ word }}
-          </div>
+        <!-- FIXME: implement displaying/editing of address label -->
+        <mat-form-field class="icon-input label-input full-width">
+          <input matInput class="label" type="text" value="{{ singleAddress.label }}" [ngClass]="{'no-label': singleAddress.label === '(No label)'}" [disabled]="addressInput" [(ngModel)]="label" (keyup.enter)="updateLabel(getUnusedAddress().address)">
+          <mat-icon matTooltip="Edit label" *ngIf="addressInput" fontSet="partIcon" fontIcon="part-pen-1" (click)="changeLabel()"></mat-icon>
+          <mat-icon matTooltip="Save label" *ngIf="!addressInput" fontSet="partIcon" fontIcon="part-circle-check" (click)="updateLabel(getUnusedAddress().address)"></mat-icon>
+        </mat-form-field>
+
+      </div><!-- .address-label -->
+
+      <!-- TODO: implement "click to copy to clipboard" -->
+      <div class="address address-string" fxLayoutWrap fxLayoutAlign="start center" matTooltip="Click to copy" matTooltipPosition="after" ngxClipboard [cbContent]="selected?.address" (click)="copyToClipBoard()">
+        <div *ngFor="let word of showAddress(singleAddress.address)" class="address-word" fxFlex="11.111">
+          {{ word }}
         </div>
       </div>
 
-      <p class="widget-help">
-        Some info..
+      <!-- TODO: if PUBLIC + MY address: -->
+      <p class="widget-help" *ngIf="type === 'public'">
+        This is your public address &ndash; its balance and transaction history is publicly visible on blockchain. If you would like to increase your privacy, use Private address instead.
+      </p>
+      <!-- TODO: if PRIVATE + MY address: -->
+      <p class="widget-help" *ngIf="type === 'private'">
+        This is your private address &ndash; its balance and transaction history is hidden for public on blockchain. For auditable addresses, use Public addresses instead.
+      </p>
+
+      <!-- TODO: if PUBLIC + SAVED 3rd-PARTY (not mine) address: -->
+      <p class="widget-help" *ngIf="type === 'public' && xxxx">
+        3rd-party's Public address (not yours) &ndash; any payments made to this address will be publicly visible on the blockchain. For increased privacy, you should ask the recipient for their Private address instead.
+      </p>
+      <!-- TODO: if PRIVATE + SAVED 3rd-PARTY (not mine) address: -->
+      <p class="widget-help" *ngIf="type === 'private' && xxxx">
+        3rd-party's Private address (not yours) &ndash; any payments made to this address will be hidden for public on the blockchain.
       </p>
 
     </div><!-- .address-details -->
@@ -54,11 +81,11 @@
   </div>
   <div class="right">
 
-    <!-- FIXME: implement functionality: -->
-    <button mat-button class="explorer">
+    <!-- FIXME: testnet condition doesn't work: -->
+    <a mat-button matTooltip="Display address' public information on Block Explorer" href="https://explorer{{testnet ? '-testnet' : ''}}.particl.io/address/{{singleAddress.address}}" target="_blank">
       <mat-icon fontSet="partIcon" fontIcon="part-info"></mat-icon>
       Show on Explorer
-    </button>
+    </a>
 
     <button mat-raised-button color="primary" ngxClipboard [cbContent]="singleAddress.address" (click)="copyToClipBoard()">
       <mat-icon fontSet="partIcon" fontIcon="part-copy"></mat-icon>

--- a/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.html
+++ b/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.html
@@ -1,4 +1,4 @@
-<div mat-dialog-title class="text-center">{{singleAddress.label}}</div>
+<div mat-dialog-title>Address details</div>
 
 <button class="small-close_button pull-right" (click)="dialogClose()">
   <mat-icon fontSet="partIcon" fontIcon="part-circle-remove"></mat-icon>
@@ -6,23 +6,64 @@
 
 <div mat-dialog-content class="dialog-content">
 
-  <div class="qr-code">
-    <div #qrCode class="card qr">
-      <qrcode [level]="'H'" size="150" qrdata="particl:{{ singleAddress.address }}"></qrcode>
-    </div>
-  </div>
+  <div class="row" fxLayout>
 
-  <div class="address-string">
-    <div class="details-address enable-select" fxLayoutWrap layout-padding>
-      <div *ngFor="let word of showAddress(singleAddress.address)" class="address-word" fxFlex="33">
-        {{ word }}
+    <div class="qr-code" fxFlex="1 0 200px">
+      <div #qrCode class="card qr">
+        <qrcode [level]="'H'" size="150" qrdata="particl:{{ singleAddress.address }}"></qrcode>
       </div>
     </div>
-  </div>
 
-  <div class="actions">
-    <button mat-button class="copy" ngxClipboard [cbContent]="singleAddress.address" (click)="copyToClipBoard()">
-      <mat-icon fontSet="partIcon" fontIcon="part-copy"></mat-icon>Copy to clipboard
-    </button>
-  </div>
+    <div class="address-details" fxFlex="1 1 100%">
+      
+      <!-- Address type (public/private)-->
+      <div class="address-type">
+        <mat-icon *ngIf="addressType === 'public'" fontSet="partIcon" fontIcon="part-public"></mat-icon>
+        <mat-icon *ngIf="addressType === 'private'" fontSet="partIcon" fontIcon="part-anon"></mat-icon>
+        {{ addressType }} address
+      </div>
+
+      <div class="label">{{ singleAddress.label }}</div>
+
+      <div class="address-string">
+        <div class="details-address enable-select" fxLayoutWrap layout-padding>
+          <div *ngFor="let word of showAddress(singleAddress.address)" class="address-word" fxFlex="33">
+            {{ word }}
+          </div>
+        </div>
+      </div>
+
+      <p class="widget-help">
+        Some info..
+      </p>
+
+    </div><!-- .address-details -->
+  </div><!-- .row -->
 </div><!-- .dialog-content -->
+
+
+<mat-dialog-actions fxLayout fxLayoutAlign="space-between center">
+  <div class="left">
+
+    <!-- FIXME: implement functionality: -->
+    <button mat-button class="explorer">
+      <mat-icon fontSet="partIcon" fontIcon="part-person-check"></mat-icon>
+      Sign/verify
+    </button>
+
+  </div>
+  <div class="right">
+
+    <!-- FIXME: implement functionality: -->
+    <button mat-button class="explorer">
+      <mat-icon fontSet="partIcon" fontIcon="part-info"></mat-icon>
+      Show on Explorer
+    </button>
+
+    <button mat-raised-button color="primary" ngxClipboard [cbContent]="singleAddress.address" (click)="copyToClipBoard()">
+      <mat-icon fontSet="partIcon" fontIcon="part-copy"></mat-icon>
+      Copy address
+    </button>
+
+  </div>
+</mat-dialog-actions>

--- a/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.html
+++ b/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.html
@@ -27,12 +27,12 @@
   <div class="right">
 
     <!-- FIXME: testnet condition doesn't work: -->
-    <a mat-button matTooltip="Display address' public information on Block Explorer" href="https://explorer{{testnet ? '-testnet' : ''}}.particl.io/address/{{singleAddress.address}}" target="_blank">
+    <a mat-button matTooltip="Display address' public information on Block Explorer" href="https://explorer{{testnet ? '-testnet' : ''}}.particl.io/address/{{singleAddress?.address}}" target="_blank">
       <mat-icon fontSet="partIcon" fontIcon="part-info"></mat-icon>
       Show on Explorer
     </a>
 
-    <button mat-raised-button color="primary" ngxClipboard [cbContent]="singleAddress.address" (click)="copyToClipBoard()">
+    <button mat-raised-button color="primary" ngxClipboard [cbContent]="singleAddress?.address" (click)="copyToClipBoard()">
       <mat-icon fontSet="partIcon" fontIcon="part-copy"></mat-icon>
       Copy address
     </button>

--- a/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.html
+++ b/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.html
@@ -23,7 +23,6 @@
   </div>
   <div class="right">
 
-    <!-- FIXME: testnet condition doesn't work: -->
     <a mat-button matTooltip="Display address' public information on Block Explorer" href="https://explorer{{testnet ? '-testnet' : ''}}.particl.io/address/{{singleAddress?.address}}" target="_blank">
       <mat-icon fontSet="partIcon" fontIcon="part-info"></mat-icon>
       Show on Explorer

--- a/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.scss
+++ b/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.scss
@@ -1,13 +1,25 @@
 @import "./src/assets/_config"; // import shared colors etc.
 
-[mat-dialog-title] {
-  word-wrap: break-word;
-}
+// ------ Modal ------ //
 
 .dialog-content {
-  min-width: 250px;
+  width: 670px;
   padding: 24px;
   margin: 24px -24px !important;
+}
+
+mat-dialog-actions {
+  border-top: 1px dashed $bg-shadow;
+  .right {
+    text-align: right;
+  }
+}
+
+
+// ------ Address details ------ //
+
+.address-details { // content block (type, label, string)
+  margin-left: 35px;
 }
 
 .address-type {
@@ -22,30 +34,17 @@
 }
 
 .address-string {
-  width: 170px;
-  margin: 20px auto 10px;
-  .details-address {
-    margin-bottom: 15px;    
-    .address-word {
-      font-family: monospace;
-      font-size: 13px;
-      color: $text-muted;
-    }
-  }
+  @extend %enable-select;
+  font-size: 15px;
+  font-family: monospace;
+  line-height: 1.45;
+  color: darken($color, 7%);
+  background: rgba($color, 0.04);
+  padding: 7px 0 7px 14px; // offset flex-wrap margin
+  margin-bottom: 18px;
+  cursor: pointer;
 }
 
-.actions {
-  .mat-icon {
-    margin-right: 7px;
-    font-size: 14px;
-    position: relative;
-    top: -1px;
-  }
-}
-
-mat-dialog-actions {
-  border-top: 1px dashed $bg-shadow;
-  .right {
-    text-align: right;
-  }
+.widget-help {
+  margin-bottom: 0;
 }

--- a/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.scss
+++ b/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.scss
@@ -1,16 +1,24 @@
 @import "./src/assets/_config"; // import shared colors etc.
 
 [mat-dialog-title] {
-  text-align: center;
-  margin: 0 50px;
-  max-width: 320px;
   word-wrap: break-word;
 }
 
 .dialog-content {
-  text-align: center;
   min-width: 250px;
-  margin-bottom: 5px !important;
+  padding: 24px;
+  margin: 24px -24px !important;
+}
+
+.address-type {
+  text-transform: uppercase;
+  color: $text-muted;
+  .mat-icon {
+    margin-right: 4px;
+    position: relative;
+    top: 3px;
+    color: lighten($text-muted, 20%);
+  }
 }
 
 .address-string {
@@ -32,5 +40,12 @@
     font-size: 14px;
     position: relative;
     top: -1px;
+  }
+}
+
+mat-dialog-actions {
+  border-top: 1px dashed $bg-shadow;
+  .right {
+    text-align: right;
   }
 }

--- a/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.scss
+++ b/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.scss
@@ -3,9 +3,9 @@
 // ------ Modal ------ //
 
 .dialog-content {
-  width: 670px;
+  width: 700px;
   padding: 24px;
-  margin: 24px -24px !important;
+  margin: 10px -24px !important;
 }
 
 mat-dialog-actions {
@@ -13,38 +13,4 @@ mat-dialog-actions {
   .right {
     text-align: right;
   }
-}
-
-
-// ------ Address details ------ //
-
-.address-details { // content block (type, label, string)
-  margin-left: 35px;
-}
-
-.address-type {
-  text-transform: uppercase;
-  color: $text-muted;
-  .mat-icon {
-    margin-right: 4px;
-    position: relative;
-    top: 3px;
-    color: lighten($text-muted, 20%);
-  }
-}
-
-.address-string {
-  @extend %enable-select;
-  font-size: 15px;
-  font-family: monospace;
-  line-height: 1.45;
-  color: darken($color, 7%);
-  background: rgba($color, 0.04);
-  padding: 7px 0 7px 14px; // offset flex-wrap margin
-  margin-bottom: 18px;
-  cursor: pointer;
-}
-
-.widget-help {
-  margin-bottom: 0;
 }

--- a/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.ts
+++ b/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild } from '@angular/core';
+import { Component, ElementRef, ViewChild, Output, EventEmitter } from '@angular/core';
 import { MatDialogRef } from '@angular/material';
 
 import { SnackbarService } from '../../../../core/core.module';
@@ -11,30 +11,23 @@ import { SnackbarService } from '../../../../core/core.module';
 export class QrCodeModalComponent {
 
   @ViewChild('qrCode') qrElementView: ElementRef;
+  @Output() onConfirm: EventEmitter<string> = new EventEmitter<string>();
 
   /* UI State */
-  public singleAddress: any = {
-    label: 'Empty label',
-    address: 'Empty address',
-    owned: false
-  };
+  public singleAddress: any;
   // FIXME: implement detecting of public/private addresses
   public type: string = 'public';
-  public label: string = '';
-  public address: string = '';
-  public addressInput: boolean = true;
-
   constructor(
     private snackbar: SnackbarService,
     public dialogRef: MatDialogRef<QrCodeModalComponent>
-  ) { }
+  ) {}
 
   getQrSize(): number {
     return this.qrElementView.nativeElement.offsetWidth;
   }
 
-  showAddress(address: string) {
-    return address.match(/.{1,4}/g);
+  get unUsedAddress(): string {
+    return this.singleAddress;
   }
 
   copyToClipBoard(): void {
@@ -45,4 +38,8 @@ export class QrCodeModalComponent {
     this.dialogRef.close();
   }
 
+  rpcLabelUpdate(msg: string) {
+    this.onConfirm.emit(msg);
+    this.dialogRef.close();
+  }
 }

--- a/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.ts
+++ b/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.ts
@@ -25,10 +25,6 @@ export class QrCodeModalComponent {
     return this.qrElementView.nativeElement.offsetWidth;
   }
 
-  get unUsedAddress(): string {
-    return this.singleAddress;
-  }
-
   copyToClipBoard(): void {
     this.snackbar.open('Address copied to clipboard', '');
   }

--- a/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.ts
+++ b/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.ts
@@ -17,6 +17,8 @@ export class QrCodeModalComponent {
     address: 'Empty address',
     owned: false
   };
+  // FIXME: implement detecting of public/private addresses
+  public addressType: string = 'public';
 
   constructor(
     private snackbar: SnackbarService,
@@ -32,7 +34,7 @@ export class QrCodeModalComponent {
   }
 
   copyToClipBoard(): void {
-    this.snackbar.open('Address copied to clipboard.', '');
+    this.snackbar.open('Address copied to clipboard', '');
   }
 
   dialogClose(): void {

--- a/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.ts
+++ b/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.ts
@@ -1,14 +1,14 @@
-import { Component, ElementRef, ViewChild, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit, ElementRef, ViewChild, Output, EventEmitter } from '@angular/core';
 import { MatDialogRef } from '@angular/material';
 
-import { SnackbarService } from '../../../../core/core.module';
+import { RpcStateService, SnackbarService } from '../../../../core/core.module';
 
 @Component({
   selector: 'app-qr-code-modal',
   templateUrl: './qr-code-modal.component.html',
   styleUrls: ['./qr-code-modal.component.scss']
 })
-export class QrCodeModalComponent {
+export class QrCodeModalComponent implements OnInit {
 
   @ViewChild('qrCode') qrElementView: ElementRef;
   @Output() onConfirm: EventEmitter<string> = new EventEmitter<string>();
@@ -16,10 +16,17 @@ export class QrCodeModalComponent {
   /* UI State */
   public singleAddress: any;
   public type: string = 'public';
+  testnet: boolean = false;
   constructor(
     private snackbar: SnackbarService,
-    public dialogRef: MatDialogRef<QrCodeModalComponent>
+    public dialogRef: MatDialogRef<QrCodeModalComponent>,
+    public rpcState: RpcStateService
   ) {}
+
+  ngOnInit(): void {
+    this.rpcState.observe('getblockchaininfo', 'chain').take(1)
+     .subscribe(chain => this.testnet = chain === 'test');
+  }
 
   getQrSize(): number {
     return this.qrElementView.nativeElement.offsetWidth;

--- a/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.ts
+++ b/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.ts
@@ -15,7 +15,6 @@ export class QrCodeModalComponent {
 
   /* UI State */
   public singleAddress: any;
-  // FIXME: implement detecting of public/private addresses
   public type: string = 'public';
   constructor(
     private snackbar: SnackbarService,

--- a/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.ts
+++ b/src/app/wallet/wallet/shared/qr-code-modal/qr-code-modal.component.ts
@@ -12,13 +12,17 @@ export class QrCodeModalComponent {
 
   @ViewChild('qrCode') qrElementView: ElementRef;
 
+  /* UI State */
   public singleAddress: any = {
     label: 'Empty label',
     address: 'Empty address',
     owned: false
   };
   // FIXME: implement detecting of public/private addresses
-  public addressType: string = 'public';
+  public type: string = 'public';
+  public label: string = '';
+  public address: string = '';
+  public addressInput: boolean = true;
 
   constructor(
     private snackbar: SnackbarService,

--- a/src/app/wallet/wallet/wallet.module.ts
+++ b/src/app/wallet/wallet/wallet.module.ts
@@ -13,7 +13,7 @@ import { ColdstakeService } from '../overview/widgets/coldstake/coldstake.servic
 
 import { TransactionsTableComponent } from './shared/transaction-table/transaction-table.component';
 import { AddressTableComponent } from './shared/address-table/address-table.component';
-
+import { DetailAddressComponent } from './shared/detail-address/detail-address.component';
 import { AddressBookComponent } from './address-book/address-book.component';
 import { ReceiveComponent } from './receive/receive.component';
 import { SendComponent } from './send/send.component';
@@ -48,6 +48,7 @@ import { WalletFixedConfirmationComponent } from './send/fix-wallet-modal/wallet
     BalanceComponent,
     AddressLookupComponent,
     AddAddressLabelComponent,
+    DetailAddressComponent,
     NewAddressModalComponent,
     QrCodeModalComponent,
     SignatureAddressModalComponent,
@@ -70,6 +71,7 @@ import { WalletFixedConfirmationComponent } from './send/fix-wallet-modal/wallet
     NewAddressModalComponent,
     QrCodeModalComponent,
     AddressLookupComponent,
+    DetailAddressComponent,
     SignatureAddressModalComponent,
     /* modals for wallet fix */
     FixWalletModalComponent,

--- a/src/assets/_config.scss
+++ b/src/assets/_config.scss
@@ -70,14 +70,12 @@ $break-xhd: 2200px;
 \* ------------------------------- */
 
 %subtitle { // section titles / H2's
-  font-size: 15px;
+  font-size: 14px;
   font-family: $font;
   font-weight: normal;
   text-transform: uppercase;
   color: $text-muted;
-  border-bottom: 1px solid $bg-shadow;
-  padding: 0 0 8px;
-  margin: 30px 0 25px;
+  margin: 30px 0 16px;
 }
 
 %box-title { // box's main title (bold, all-caps)

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -89,16 +89,23 @@ body {
   position: fixed;
   top: $header-main-height;
   z-index: 100;
-  width: 100%;
+  left: $sidebar-width;
+  right: 6px;
   background: rgba($bg, 0.95);
+  .buttons {
+    flex: 1 0 100px;
+    padding: 0 20px 0 20px; // offset side padding
+    //border-left: 1px solid $bg-shadow;
+    border-bottom: 1px solid $bg-shadow;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+  }
 }
 
 // sticky control bars (eg. on Listings page)
 .control-bar {
   @extend .tab-bar;
-  left: $sidebar-width;
-  right: 6px;
-  width: auto;
   padding: 0 28px 0 $padding;
   border-bottom: 1px solid $bg-shadow;
 }
@@ -272,7 +279,8 @@ body {
 // Help descriptions
 .widget-help {
   color: $text-muted;
-  font-size: 11px;
+  font-size: 12px;
+  line-height: 1.45;
   margin-bottom: 25px;
   cursor: help;
 }


### PR DESCRIPTION
> WORK IN PROGRESS, don't merge

## Done

### Overview

- UI/UX unification (closes **`PD-390`**, **`PD-391`** & **`PD-392`**)
- tweaks to Staking widgets

### Send

- UI/UX unification (typography, sticky layout – [preview](https://user-images.githubusercontent.com/1965795/47515093-3917a880-d882-11e8-9420-b38833615019.png))
- `Advanced options` button moved to tab bar, so it's still visible and available (even when scrolled down)

### Help

- added links to forum, exchanges ([preview](https://user-images.githubusercontent.com/1965795/47515086-34eb8b00-d882-11e8-8e75-a974e9cd0b96.png))

### Receive & Address book

- redesigned list of addresses ([preview](https://user-images.githubusercontent.com/1965795/47996270-42153f00-e0f8-11e8-9851-ade5e39f4e88.png))
- Address book: redesigned "save new address" modal ([preview](https://user-images.githubusercontent.com/1965795/47996288-59542c80-e0f8-11e8-8dc0-2dc8a60b9fd7.png)) and "delete address"
- closes **`PD-414`**

### Address details

- modal updated (`qr-code-modal` – [preview](https://user-images.githubusercontent.com/1965795/47515078-2ef5aa00-d882-11e8-9aa0-2e0651ed0fbb.png))
- this will replace `new-address-modal` & `add-address-label`
- closes **`PD-422`**, **`PD-404`**, **`PD-405`**

### Misc.

- made help descriptions a bit larger + bigger line spacing so better readability