### PR TITLE
Removes unnecessary tabs from Add/Verify signature modal.

### DIFF
--- a/src/app/wallet/wallet/shared/signature-address-modal/signature-address-modal.component.html
+++ b/src/app/wallet/wallet/shared/signature-address-modal/signature-address-modal.component.html
@@ -6,13 +6,13 @@
 
   <form [formGroup]="addressForm" novalidate (ngSubmit)="onFormSubmit()">
     <div mat-dialog-container>
-      <mat-tab-group (selectChange)="selectTab($event.index)" [(selectedIndex)]="tabIndex">
-        <mat-tab label="Sign Message">
+      <mat-tab-group>
+        <mat-tab label="Sign Message" *ngIf="type === 'sign'">
           <p>
             You can sign messages/agreements with your address to prove you can receive Particl sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.
           </p>
         </mat-tab>
-        <mat-tab label="Verify Message">
+        <mat-tab label="Verify Message" *ngIf="type === 'verify'">
           <p>
             Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack. Note that this only proves the signing party receives with the address, it cannot prove sendership of any transaction!
           </p>

--- a/src/app/wallet/wallet/shared/signature-address-modal/signature-address-modal.component.ts
+++ b/src/app/wallet/wallet/shared/signature-address-modal/signature-address-modal.component.ts
@@ -27,7 +27,6 @@ export class SignatureAddressModalComponent implements OnInit {
   public addressForm: FormGroup;
   public isDisabled: boolean = true;
   public isAddressLookup: boolean = false;
-  public tabIndex: number = 1;
 
   log: any = Log.create('SignatureAddressModalComponent.component');
 
@@ -47,10 +46,8 @@ export class SignatureAddressModalComponent implements OnInit {
 
   ngOnInit() {
     if (this.type === 'verify') {
-      this.tabIndex = 1;
       this.isDisabled = false;
     } else {
-      this.tabIndex = 0;
       this.type = 'sign';
     }
     this.buildForm();
@@ -62,12 +59,6 @@ export class SignatureAddressModalComponent implements OnInit {
       signature: this.formBuilder.control({value: null, disabled: this.isDisabled}, [Validators.required]),
       message: this.formBuilder.control(null),
     });
-  }
-
-  selectTab(index: number): void {
-    this.type = (index) ? 'verify' : 'sign';
-    this.isDisabled = (this.type !== 'verify');
-    this.buildForm();
   }
 
   openLookup(): void {


### PR DESCRIPTION
Context is provided by the source page.