### PR TITLE
GFX tweaks (No. XI)

### DIFF
--- a/src/app/market/_listing.scss
+++ b/src/app/market/_listing.scss
@@ -16,6 +16,7 @@
     .photo { // crop listing's image to square
       min-height: 110px;
       max-height: 110px;
+      height: 110px;
     }
     .meta .name {
       font-size: 16px;

--- a/src/app/market/_lists-shared.scss
+++ b/src/app/market/_lists-shared.scss
@@ -59,6 +59,7 @@
     .description {
       p {
         white-space: pre-line;
+        word-wrap: break-word;
         margin-top: -17px;
       }
     }

--- a/src/app/market/_lists-shared.scss
+++ b/src/app/market/_lists-shared.scss
@@ -14,7 +14,10 @@
       margin-right: 24px;
       img {
         width: 100%;
+        height: 100%;
         display: block;
+        object-fit: cover;
+        object-position: center;
       }
     }
     .meta {

--- a/src/app/market/_order.scss
+++ b/src/app/market/_order.scss
@@ -8,6 +8,7 @@
     .photo { // crop orders's image to square
       min-height: 80px;
       max-height: 80px;
+      height: 80px;
     }
   }
 }

--- a/src/app/market/listings/listing-item/listing-item.component.scss
+++ b/src/app/market/listings/listing-item/listing-item.component.scss
@@ -16,9 +16,8 @@
   img {
     display: block;
     width: 100%;
-    height: auto;
-    cursor: pointer;
     height: 218px;
+    cursor: pointer;
     object-fit: cover;
     object-position: center;
   }

--- a/src/app/market/listings/listings.component.scss
+++ b/src/app/market/listings/listings.component.scss
@@ -56,6 +56,15 @@
       padding-right: 0;
       display: flex;
       align-items: center;
+      mat-button-toggle.reported-only {
+        &.mat-button-toggle-checked {
+          color: $color-alert;
+          background: rgba($color-alert, 0.10) !important;
+          &:hover {
+            background: rgba($color-alert, 0.15) !important;
+          }
+        }
+      }
     }
   }
 }

--- a/src/app/market/listings/preview-listing/preview-listing.component.scss
+++ b/src/app/market/listings/preview-listing/preview-listing.component.scss
@@ -145,6 +145,8 @@ button.small .mat-icon {
   // Text description
   .description {
     margin: 18px 0;
+    word-wrap: break-word;
+    width: 438px;
     &.summary {
       font-weight: 600;
       color: $text;

--- a/src/app/market/sell/sell.component.scss
+++ b/src/app/market/sell/sell.component.scss
@@ -9,3 +9,14 @@
 }
 
 // ------ LAYOUT ------ //
+
+.loading-container {
+  $padding: 35px;
+  left: ($sidebar-width + $filter-width + (2 * $padding));
+  right: $padding;
+  @include break(l) {
+    $padding-l: 50px;
+    left: ($sidebar-width + $filter-width + (2 * $padding-l));
+    right: $padding-l;
+  }
+}

--- a/src/app/market/shared/report/report.component.html
+++ b/src/app/market/shared/report/report.component.html
@@ -7,10 +7,9 @@
         (click)="toggle()"></mat-icon>
 
 <button *ngIf="from === 'preview'" mat-button class="small" 
-        [color]="listing?.isFlagged ? 'warn' : 'basic'" 
+        [color]="listing?.isFlagged ? 'warn' : 'basic'" (click)="toggle()"
         [matTooltip]="listing?.isFlagged ? 'Item has been reported' : 'Report'"
         matTooltipPosition="above">
   <mat-icon fontSet="partIcon" fontIcon="part-flag"
-      [ngClass]="{ 'active': listing?.isFlagged }"
-      (click)="toggle()"></mat-icon>
+      [ngClass]="{ 'active': listing?.isFlagged }"></mat-icon>
 </button>

--- a/src/app/modals/_confirmations-shared.scss
+++ b/src/app/modals/_confirmations-shared.scss
@@ -8,18 +8,8 @@
 // ------ UI ------ //
 
 .title {
-  // FIXME: swith to @extend %box-title;
-  text-transform: uppercase;
-  font-weight: bold;
-  font-size: 13px;
-}
-
-.help-text {
-  // FIXME: switch to: @extend %help-text;
-  color: $text-muted;
-  font-size: 11px;
-  margin-bottom: 25px;
-  cursor: help;
+  @extend %box-title;
+  margin: 6px 0;
 }
 
 
@@ -91,7 +81,7 @@
 .fee-info {
   // FIXME: switch to: @extend %help-text;
   color: $text-muted;
-  font-size: 11px;
+  font-size: 12px;
   margin: 30px 0 0;
   & > .amount {
     margin: 0 0 0 10px;

--- a/src/app/modals/proposal-vote-confirmation/proposal-vote-confirmation.component.html
+++ b/src/app/modals/proposal-vote-confirmation/proposal-vote-confirmation.component.html
@@ -11,31 +11,40 @@
     <div class="tx-info">
       <mat-icon class="icon" fontSet="partIcon" fontIcon="part-person-check"></mat-icon>
       <div class="title">You're voting</div>
-      <p class="help-text">
+      <p class="widget-help">
         You’re voting on a proposal
       </p>
     </div>
 
-    <div class="vote-choice">
-      {{data?.selectedOption?.description}}
-    </div>
-
-    <mat-icon class="icon arrow" fontSet="partIcon" fontIcon="part-arrow-down"></mat-icon>
-
     <div class="proposal-name">
-      {{data?.title}}
+      {{ data?.title }}
     </div>
-  </div><!-- TX confirmation -->
+    
+    <mat-icon class="icon arrow" fontSet="partIcon" fontIcon="part-arrow-down"></mat-icon>
+    
+    <div class="vote-choice">
+      {{ data?.selectedOption?.description }}
+    </div>
 
+    <p class="fee-info">
+      <!-- FIXME: implement fee info -->
+      Transaction fee:<span class="amount TO_DO">xx PART</span><span class="fiat">&asymp; 0.05 USD</span><br>
+    </p>
+
+  </div><!-- TX confirmation -->
 </div><!-- .dialog-content -->
 
+
 <mat-dialog-actions fxLayoutAlign="space-between center">
+
   <button mat-button mat-dialog-close (click)="dialogClose()">
     <mat-icon fontSet="partIcon" fontIcon="part-cross"></mat-icon>
     Cancel
   </button>
+
   <button mat-raised-button color="primary" mat-dialog-close (click)="confirm()">
     <mat-icon fontSet="partIcon" fontIcon="part-check"></mat-icon>
     Confirm &amp; Vote
   </button>
+
 </mat-dialog-actions>

--- a/src/app/modals/proposal-vote-confirmation/proposal-vote-confirmation.component.html
+++ b/src/app/modals/proposal-vote-confirmation/proposal-vote-confirmation.component.html
@@ -4,8 +4,6 @@
 </button>
 
 <div mat-dialog-content class="dialog-content">
-
-  <!--TX confirmation-->
   <div class="tx-confirmation">
 
     <div class="tx-info">
@@ -25,11 +23,6 @@
     <div class="vote-choice">
       {{ data?.selectedOption?.description }}
     </div>
-
-    <p class="fee-info">
-      <!-- FIXME: implement fee info -->
-      Transaction fee:<span class="amount TO_DO">xx PART</span><span class="fiat">&asymp; 0.05 USD</span><br>
-    </p>
 
   </div><!-- TX confirmation -->
 </div><!-- .dialog-content -->

--- a/src/app/modals/report-modal/report-modal.component.html
+++ b/src/app/modals/report-modal/report-modal.component.html
@@ -1,23 +1,29 @@
-<div>
-  <div mat-dialog-title class="title">Report Listing</div>
-  <mat-dialog-content class="modal-content" fxLayout>
-    <div class="text" fxFlex="1 1 350px">
-      <p class="lead" *ngIf="!option">
-        Are you sure you want to report {{title}} as an inappropriate listing ?
-      </p>
-      <!-- <p class="lead" *ngIf="option">
-        You are about to change your vote on {{title}}, are you sure the listing is market appropriate?
-      </p> -->
-    </div>
-  </mat-dialog-content>
-  <mat-dialog-actions fxLayoutAlign="end center">
-    <button type="button" mat-button mat-dialog-close>
-      <mat-icon fontSet="partIcon" fontIcon="part-cross"></mat-icon>
-      No, cancel
-    </button>
-    <button mat-raised-button color="primary" (click)="flag()">
-      <mat-icon fontSet="partIcon" fontIcon="part-check"></mat-icon>
-      Yes
-    </button>
-  </mat-dialog-actions>
-</div>
+<div mat-dialog-title class="title">Report Listing</div>
+
+
+<mat-dialog-content class="modal-content">
+  <p class="lead">
+    Are you sure you want to report this Listing as inappropriate?
+  </p>
+  <p class="listing-name">
+    {{ title }}
+  </p>
+  <p class="widget-help">
+    Users have the ability to self-govern the Marketplace and remove illegal and other inappropriate Listings. By reporting this Listing, you vote (with the weight of your coins) to take it down from the Marketplace.
+  </p>
+</mat-dialog-content>
+
+
+<mat-dialog-actions>
+
+  <button type="button" mat-button mat-dialog-close>
+    <mat-icon fontSet="partIcon" fontIcon="part-cross"></mat-icon>
+    Cancel
+  </button>
+
+  <button mat-raised-button color="warn" (click)="flag()">
+    <mat-icon fontSet="partIcon" fontIcon="part-flag"></mat-icon>
+    Yes, Report
+  </button>
+
+</mat-dialog-actions>

--- a/src/app/modals/report-modal/report-modal.component.html
+++ b/src/app/modals/report-modal/report-modal.component.html
@@ -1,5 +1,5 @@
 <div mat-dialog-title>Report Listing</div>
-<button class="small-close_button pull-right"><!-- FIXME: (click)="dialogClose()" -->
+<button class="small-close_button pull-right" (click)="dialogClose()">
   <mat-icon fontSet="partIcon" fontIcon="part-circle-remove"></mat-icon>
 </button>
 
@@ -26,11 +26,6 @@
     <div class="receiver-info">
       <div class="label">Inappropriate, take down!</div>
     </div>
-
-    <p class="fee-info">
-      <!-- FIXME: implement fee info -->
-      Transaction fee:<span class="amount TO_DO">xx PART</span><span class="fiat">&asymp; 0.05 USD</span><br>
-    </p>
 
   </div><!-- TX confirmation -->
 </div><!-- .dialog-content -->

--- a/src/app/modals/report-modal/report-modal.component.html
+++ b/src/app/modals/report-modal/report-modal.component.html
@@ -1,20 +1,42 @@
-<div mat-dialog-title class="title">Report Listing</div>
+<div mat-dialog-title>Report Listing</div>
+<button class="small-close_button pull-right"><!-- FIXME: (click)="dialogClose()" -->
+  <mat-icon fontSet="partIcon" fontIcon="part-circle-remove"></mat-icon>
+</button>
 
 
-<mat-dialog-content class="modal-content">
-  <p class="lead">
-    Are you sure you want to report this Listing as inappropriate?
-  </p>
-  <p class="listing-name">
-    {{ title }}
-  </p>
-  <p class="widget-help">
-    Users have the ability to self-govern the Marketplace and remove illegal and other inappropriate Listings. By reporting this Listing, you vote (with the weight of your coins) to take it down from the Marketplace.
-  </p>
-</mat-dialog-content>
+<div mat-dialog-content class="dialog-content">
+  <div class="tx-confirmation">
+
+    <div class="tx-info">
+      <div class="public">
+        <mat-icon class="icon report" fontSet="partIcon" fontIcon="part-flag"></mat-icon>
+        <div class="title">Reporting Listing</div>
+        <p class="widget-help">
+          Users have the ability to self-govern the Marketplace and remove illegal and other inappropriate Listings. By reporting this Listing, you vote (with the weight of your coins) to take it down from the Marketplace.
+        </p>
+      </div>
+    </div><!-- .tx-info -->
+
+    <div class="tx-amount">
+      <span class="big">{{ title }}</span>
+    </div>
+
+    <mat-icon class="icon arrow" fontSet="partIcon" fontIcon="part-arrow-down"></mat-icon>
+
+    <div class="receiver-info">
+      <div class="label">Inappropriate, take down!</div>
+    </div>
+
+    <p class="fee-info">
+      <!-- FIXME: implement fee info -->
+      Transaction fee:<span class="amount TO_DO">xx PART</span><span class="fiat">&asymp; 0.05 USD</span><br>
+    </p>
+
+  </div><!-- TX confirmation -->
+</div><!-- .dialog-content -->
 
 
-<mat-dialog-actions>
+<mat-dialog-actions fxLayoutAlign="space-between center">
 
   <button type="button" mat-button mat-dialog-close>
     <mat-icon fontSet="partIcon" fontIcon="part-cross"></mat-icon>

--- a/src/app/modals/report-modal/report-modal.component.scss
+++ b/src/app/modals/report-modal/report-modal.component.scss
@@ -1,1 +1,19 @@
 @import "./src/assets/_config"; // import shared colors etc.
+
+.modal-content {
+  max-width: 500px;
+
+  .listing-name { // name of reported listing
+    background: $bg;
+    margin: 24px 0;
+    padding: 16px 24px;
+    font-size: 15px;
+    font-weight: 500;
+  }
+}
+
+mat-dialog-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}

--- a/src/app/modals/report-modal/report-modal.component.scss
+++ b/src/app/modals/report-modal/report-modal.component.scss
@@ -1,19 +1,12 @@
 @import "./src/assets/_config"; // import shared colors etc.
+@import "./src/app/modals/_confirmations-shared"; // shared stuff for confirmation modals
 
-.modal-content {
-  max-width: 500px;
 
-  .listing-name { // name of reported listing
-    background: $bg;
-    margin: 24px 0;
-    padding: 16px 24px;
-    font-size: 15px;
-    font-weight: 500;
+// ------ LAYOUT ------ //
+
+.tx-info {
+  .icon.report {
+    font-size: 26px;
+    color: $color-alert;
   }
-}
-
-mat-dialog-actions {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
 }

--- a/src/app/modals/report-modal/report-modal.component.ts
+++ b/src/app/modals/report-modal/report-modal.component.ts
@@ -18,4 +18,9 @@ export class ReportModalComponent implements OnInit {
     this._dialogRef.close();
     this.isConfirmed.emit();
   }
+
+  dialogClose(): void {
+    this._dialogRef.close();
+  }
+
 }

--- a/src/app/modals/send-confirmation-modal/send-confirmation-modal.component.html
+++ b/src/app/modals/send-confirmation-modal/send-confirmation-modal.component.html
@@ -12,7 +12,7 @@
       <div class="public" *ngIf="transactionType === 'part'">
         <mat-icon class="icon public" fontSet="partIcon" fontIcon="part-public"></mat-icon>
         <div class="title">Public transaction</div>
-        <p class="help-text">
+        <p class="widget-help">
           Sender, Receiver & transaction amount will be publicly visible on the blockchain
         </p>
       </div>
@@ -20,14 +20,14 @@
       <div class="blind" *ngIf="transactionType === 'blind'">
         <mat-icon class="icon public" fontSet="partIcon" fontIcon="part-blind"></mat-icon>
         <div class="title">Blind transaction</div>
-        <p class="help-text">
+        <p class="widget-help">
           Sender & Receiver will be publicly visible on the blockchain, but the transaction amount will be hidden
         </p>
       </div>
       <div class="anon" *ngIf="transactionType === 'anon'">
         <mat-icon class="icon public" fontSet="partIcon" fontIcon="part-anon"></mat-icon>
         <div class="title">Anon transaction</div>
-        <p class="help-text">
+        <p class="widget-help">
           Sender, Receiver & transaction amount will be hidden on the blockchain for highest privacy
         </p>
       </div>

--- a/src/app/wallet/wallet/shared/transaction-table/transaction-table.component.html
+++ b/src/app/wallet/wallet/shared/transaction-table/transaction-table.component.html
@@ -16,90 +16,86 @@
 <ng-container *ngFor="let tx of txService.txs">
   <mat-expansion-panel class="history-list" [expanded]="checkExpandDetails(tx)">
 
-    <mat-expansion-panel-header fxLayout="row" fxLayoutGap="10px" (click)="showExpandedTransactionDetail(tx)" layout-padding>
+    <mat-expansion-panel-header (click)="showExpandedTransactionDetail(tx)">
+      <mat-panel-title class="tx-overview" fxLayout="row" fxLayoutAlign="space-between center" fxLayoutGap="10px">
 
-      <!-- Date -->
-      <mat-panel-title fxFlex="0 0 85px" fxFlex.lt-md="100" *ngIf="display.date" class="history_date">
-        {{ tx.getDate() }}
-      </mat-panel-title>
+        <!-- Date -->
+        <div fxFlex="0 0 135px" *ngIf="display.date" class="history_date">
+          {{ tx.getDate() }}
+        </div>
 
-      <!-- Confirmations -->
-      <mat-panel-title fxFlex="0 0 50px" fxFlex.lt-md="100" *ngIf="display.confirmations" class="history_confirmation"
-                        [ngClass]="styleConfimations(tx.getConfirmationCount())">
-        <span mat-line matTooltip="Confirmations" matTooltipPosition="before">
-          <mat-icon fontSet="partIcon" fontIcon="part-circle-check" class="confirmations"></mat-icon>
-          {{ tx.getConfirmationCount() }}
-        </span>
-      </mat-panel-title>
+        <!-- Confirmations -->
+        <div fxFlex="0 0 70px" *ngIf="display.confirmations && tx.getConfirmationCount() <= 12" class="history_confirmation" [ngClass]="styleConfimations(tx.getConfirmationCount())">
+          <div class="confirmation-tag" matTooltip="Unconfirmed transaction" matTooltipPosition="before">
+            <mat-icon fontSet="partIcon" fontIcon="part-date" class="confirmations"></mat-icon>
+            {{ tx.getConfirmationCount() }}/12
+          </div>
+        </div>
 
-      <!-- Category icon -->
-      <mat-panel-title fxFlex="1 0 175px" fxFlex.lt-md="100" *ngIf="display.category" class="history_cat_icon"
-                        [ngSwitch]="tx.getCategory()">
-        <span *ngSwitchCase="'stake'" class="tx-type staked">
-          <mat-icon fontSet="partIcon" fontIcon="part-stake"></mat-icon>
-          <span class="name">Staked</span>
-        </span>
-        <span *ngSwitchCase="'orphaned_stake'" class="tx-type orphan">
-          <mat-icon fontSet="partIcon" fontIcon="part-alert" color="warn"></mat-icon>
-          <span class="name">Orphaned Stake</span>
-        </span>
-        <span *ngSwitchCase="'send'" class="tx-type sent">
-          <mat-icon fontSet="partIcon" fontIcon="part-send" color="warn"></mat-icon>
-          <span class="name">Sent</span>
-          <mat-icon class="narration" *ngIf="tx.getNarration()" fontSet="partIcon" fontIcon="part-pen-1"
-                    matTooltip="{{tx.getNarration()}}" matTooltipPosition="after"></mat-icon>
-        </span>
-        <span *ngSwitchCase="'multisig'" class="tx-type sent">
-          <mat-icon fontSet="partIcon" fontIcon="part-lock-open" color="warn"></mat-icon>
-          <span class="name">Multisig / escrow</span>
-          <mat-icon class="narration" *ngIf="tx.getNarration()" fontSet="partIcon" fontIcon="part-pen-1"
-                    matTooltip="{{tx.getNarration()}}" matTooltipPosition="after"></mat-icon>
-        </span>
-        <span *ngSwitchCase="'receive'" class="tx-type received">
-          <mat-icon fontSet="partIcon" fontIcon="part-receive" color="primary"></mat-icon>
-          <span class="name">Received</span>
-          <mat-icon class="narration" *ngIf="tx.getNarration()" fontSet="partIcon" fontIcon="part-pen-1"
-                    matTooltip="{{tx.getNarration()}}" matTooltipPosition="after"></mat-icon>
-        </span>
-        <span *ngSwitchCase="'internal_transfer'" class="tx-type received">
-          <mat-icon fontSet="partIcon" fontIcon="part-transfer" color="primary"></mat-icon>
-          <span class="name">Balance transfer</span>
-        </span>
-        <span *ngSwitchCase="'listing_fee'" class="tx-type sent">
-          <mat-icon fontSet="partIcon" fontIcon="part-bag-buy" color="primary"></mat-icon>
-          <span class="name">Posted Listing</span>
-        </span>
-      </mat-panel-title>
-
-      <!-- Address -->
-      <!--mat-panel-title fxFlex.lg="57" fxFlex.lt-md="100" *ngIf="display.senderAddress" class="history_longAddress">
-        {{ tx.getAddress() }}
-      </mat-panel-title-->
-
-      <mat-panel-title fxFlex="20" fxFlex.lt-md="100" *ngIf="display.txid" class="history_txt">
-        <span mat-line fxLayout.md="row" fxFlex="100%" fxLayout.lg="row">
-          <span fxFlex="10"><b>TxId</b></span>
-          <span fxFlex="80">{{ tx.txid }} </span>
-        </span>
-      </mat-panel-title>
-
-      <mat-panel-title fxFlex="20" fxFlex.lt-md="100" *ngIf="display.blockIndex" class="history_blockIndex">
-        <span mat-line>Blockindex {{ tx.blockindex }}</span>
-      </mat-panel-title>
-
-      <!-- Amount -->
-      <mat-panel-title fxFlex="1 0 155px" fxFlex.lt-md="100" *ngIf="display.amount" class="history_amount">
-        <span mat-line>
-          <span class="amount"
-                [ngClass]="{'positive': tx.getAmountObject().getAmount() > 0, 'negative': tx.getAmountObject().getAmount() < 0 }">
-            <span class="big number">{{ tx.getAmountObject().getIntegerPart() }}</span><!-- inline element comment hack
-            --><span class="point">{{ tx.getAmountObject().dot() }}</span><!--
-            --><small class="small number">{{ tx.getAmountObject().getFractionalPart() || '' }}</small>
-            <span class="currency">PART</span>
+        <!-- Category icon -->
+        <div fxFlex="1 0 175px" *ngIf="display.category" class="history_cat_icon"
+                          [ngSwitch]="tx.getCategory()">
+          <span *ngSwitchCase="'stake'" class="tx-type staked">
+            <mat-icon fontSet="partIcon" fontIcon="part-stake"></mat-icon>
+            <span class="name">Staked</span>
           </span>
-        </span>
-      </mat-panel-title>
+          <span *ngSwitchCase="'orphaned_stake'" class="tx-type orphan">
+            <mat-icon fontSet="partIcon" fontIcon="part-alert" color="warn"></mat-icon>
+            <span class="name">Orphaned Stake</span>
+          </span>
+          <span *ngSwitchCase="'send'" class="tx-type sent">
+            <mat-icon fontSet="partIcon" fontIcon="part-send" color="warn"></mat-icon>
+            <span class="name">Sent</span>
+            <mat-icon class="narration" *ngIf="tx.getNarration()" fontSet="partIcon" fontIcon="part-pen-1"
+                      matTooltip="{{tx.getNarration()}}" matTooltipPosition="after"></mat-icon>
+          </span>
+          <span *ngSwitchCase="'multisig'" class="tx-type sent">
+            <mat-icon fontSet="partIcon" fontIcon="part-lock-open" color="warn"></mat-icon>
+            <span class="name">Multisig / escrow</span>
+            <mat-icon class="narration" *ngIf="tx.getNarration()" fontSet="partIcon" fontIcon="part-pen-1"
+                      matTooltip="{{tx.getNarration()}}" matTooltipPosition="after"></mat-icon>
+          </span>
+          <span *ngSwitchCase="'receive'" class="tx-type received">
+            <mat-icon fontSet="partIcon" fontIcon="part-receive" color="primary"></mat-icon>
+            <span class="name">Received</span>
+            <mat-icon class="narration" *ngIf="tx.getNarration()" fontSet="partIcon" fontIcon="part-pen-1"
+                      matTooltip="{{tx.getNarration()}}" matTooltipPosition="after"></mat-icon>
+          </span>
+          <span *ngSwitchCase="'internal_transfer'" class="tx-type received">
+            <mat-icon fontSet="partIcon" fontIcon="part-transfer" color="primary"></mat-icon>
+            <span class="name">Balance transfer</span>
+          </span>
+          <span *ngSwitchCase="'listing_fee'" class="tx-type sent">
+            <mat-icon fontSet="partIcon" fontIcon="part-bag-buy" color="primary"></mat-icon>
+            <span class="name">Posted Listing</span>
+          </span>
+        </div>
 
+        <div fxFlex="20" *ngIf="display.txid" class="history_txt">
+          <span mat-line fxLayout.md="row" fxFlex="100%" fxLayout.lg="row">
+            <span fxFlex="10"><b>TxId</b></span>
+            <span fxFlex="80">{{ tx.txid }} </span>
+          </span>
+        </div>
+
+        <div fxFlex="20" *ngIf="display.blockIndex" class="history_blockIndex">
+          <span mat-line>Blockindex {{ tx.blockindex }}</span>
+        </div>
+
+        <!-- Amount -->
+        <div fxFlex="1 0 155px" *ngIf="display.amount" class="history_amount">
+          <span mat-line>
+            <span class="amount"
+                  [ngClass]="{'positive': tx.getAmountObject().getAmount() > 0, 'negative': tx.getAmountObject().getAmount() < 0 }">
+              <span class="big number">{{ tx.getAmountObject().getIntegerPart() }}</span><!-- inline element comment hack
+              --><span class="point">{{ tx.getAmountObject().dot() }}</span><!--
+              --><small class="small number">{{ tx.getAmountObject().getFractionalPart() || '' }}</small>
+              <span class="currency">PART</span>
+            </span>
+          </span>
+        </div>
+
+      </mat-panel-title><!-- .tx-overview -->
     </mat-expansion-panel-header>
 
 

--- a/src/app/wallet/wallet/shared/transaction-table/transaction-table.component.scss
+++ b/src/app/wallet/wallet/shared/transaction-table/transaction-table.component.scss
@@ -6,12 +6,18 @@
   // TX date/time
   .history_date {
     color: $text-muted;
-    border-right: 1px solid lighten($text-muted, 35%);
+    //border-right: 1px solid lighten($text-muted, 35%);
   }
 
   // confirmations
   .history_confirmation {
     color: $text-muted;
+    .confirmation-tag {
+      border-radius: $radius;
+      font-size: 12px;
+      display: inline-block;
+      padding: 5px 10px;
+    }
     .confirmations { // icon
       margin-right: 3px;
       font-size: 12px;
@@ -20,15 +26,27 @@
     }
     &.confirm-none { // unconfirmed TXs
       color: mix($color-alert, $color-warning, 100%);
+      .confirmation-tag {
+        background: rgba(mix($color-alert, $color-warning, 100%), 0.15);
+      }
     }
     &.confirm-1 { // 1-4 confirmations
       color: mix($color-alert, $color-warning, 66%);
+      .confirmation-tag {
+        background: rgba(mix($color-alert, $color-warning, 66%), 0.15);
+      }
     }
     &.confirm-2 { // 5-8 conf.
       color: mix($color-alert, $color-warning, 33%);
+      .confirmation-tag {
+        background: rgba(mix($color-alert, $color-warning, 33%), 0.15);
+      }
     }
     &.confirm-3 { // 9-12 conf.
       color: mix($color-alert, $color-warning, 0%);
+      .confirmation-tag {
+        background: rgba(mix($color-alert, $color-warning, 0%), 0.15);
+      }
     }
     &.confirm-ok {
       color: lighten($text-muted, 20%);

--- a/src/assets/_config.scss
+++ b/src/assets/_config.scss
@@ -81,7 +81,7 @@ $break-xhd: 2200px;
 %box-title { // box's main title (bold, all-caps)
   text-transform: uppercase;
   font-weight: 700;
-  font-size: 13px;
+  font-size: 15px;
 }
 
 %tag { // notification tags - e.g. in tabs: Orders [3]

--- a/src/assets/scss/_material-components.scss
+++ b/src/assets/scss/_material-components.scss
@@ -559,5 +559,9 @@ input {
   box-shadow: none !important;
   &:hover, &:focus {
     background: darken($bg, 10%) !important;
+    color: $text;
+  }
+  .mat-button-toggle-focus-overlay {
+    opacity: 0 !important; // fixes weird behaviour of overlay layer
   }
 }


### PR DESCRIPTION
> **Ready for review & merge!**

### Overview/History
- fix overflowing date & time
- show confirmation info only if TX = unconfirmed

![screenshot from 2018-11-12 18-23-12](https://user-images.githubusercontent.com/1965795/48364290-4fa66800-e6a8-11e8-9e94-72a778dbb2ac.png)

### Listings
- styling of "show reported only" button

### Sell
- Listings: show loader only over content (not sidebar)

### Orders/Listings
- fix thumbnails (cover container)
- fix absurdly long descriptions etc. (closes `PD-471`)

### Reporting modal (`report-modal.component`)

- layout redesign (closes #1241)

![screenshot from 2018-11-12 16-26-16](https://user-images.githubusercontent.com/1965795/48357519-19adb780-e699-11e8-991e-cddd922024d0.png)

### Proposal voting (`proposal-vote-confirmation.component`)
- layout update

