### PR TITLE
GFX: Page intros

### DIFF
--- a/src/app/wallet/proposals/add-proposal/add-proposal.component.html
+++ b/src/app/wallet/proposals/add-proposal/add-proposal.component.html
@@ -1,157 +1,163 @@
-<div class="hero-block">
-  <div class="title">New Community Proposal</div>
-  <p>
-    Submit a proposal on the Particl network for the community to vote on.<br>
-    Proposals can include: suggestions for features, community-led initiatives, partnership opportunities, protocol improvement ideas, and much more.
-  </p>
-  <p class="widget-help">
-    Keep in mind that each Proposal fee costs depends on the content size to submit and that voting results do not guarantee implementation from the Particl team.
-  </p>
-</div>
-
-<div class="container-block" [formGroup]="proposalFormGroup">
-
-  <div class="column">
-
-    <mat-card>
-      <div class="title">Proposal details</div>
-
-      <mat-form-field class="full-width">
-        <input matInput #title placeholder="Proposal's title" formControlName="title">
-        <mat-hint align="end">{{ title.value?.length || 0 }}/50</mat-hint>
-      </mat-form-field>
-
-      <mat-form-field class="full-width">
-        <textarea matInput #description rows="25" placeholder="Description" formControlName="description"></textarea>
-        <mat-hint align="end">{{ description.value?.length || 0 }}/2000</mat-hint>
-      </mat-form-field>
-
-      <p class="widget-help">
-        Objectively describe your proposal in detail; explain what to change, how to do it and why.
-      </p>
-    </mat-card>
-    
-    <!-- <mat-card>
-      <div class="title to-do">Voting period</div>
+<div class="container-block without-tab-bar">
+  <div class="page-intro">
+    <h1>New Community Proposal</h1>
+    <div class="content">
       <p>
-        Specify when will the proposal be active for voting:
+        Submit a proposal on the Particl network for the community to vote on.<br>
+        Proposals can include: suggestions for features, community-led initiatives, partnership opportunities, protocol improvement ideas, and much more.
       </p>
-      <div class="voting-period">
-        <!- TODO: populate the "voting-starts" input with: <current block> + 2000 (~ 3 days in future) ->
-        <!- TODO: implement "min" attribe which should be equal to current block (= can't submit new proposal retroactively) ->
-        <mat-form-field class="half-width">
-          <input matInput type="number" placeholder="Voting starts on block #" formControlName="voting-starts">
-        </mat-form-field>
-        <mat-form-field class="half-width voting-length" floatPlaceholder="never">
-          <mat-select placeholder="Voting period">
-            <mat-option value="9500">9500 blocks (~ 2 weeks)</mat-option>
-            <mat-option value="20000">20000 blocks (~ 1 month)</mat-option>
-            <mat-option value="40000">40000 blocks (~ 2 months)</mat-option>
-            <mat-option value="60000">60000 blocks (~ 3 months)</mat-option>
-          </mat-select>
-        </mat-form-field>
-      </div>
       <p class="widget-help">
-        Note: 1 day equals to approx. 670 blocks. Current block: <strong class="to-do">XXXXXX</strong>
+        Keep in mind that each Proposal fee costs depends on the content size to submit and that voting results do not guarantee implementation from the Particl team.
       </p>
-    </mat-card> -->
+    </div>
+  </div><!-- .page-intro -->
 
-  </div><!-- .column -->
+  <div class="row" [formGroup]="proposalFormGroup">
   
-
-  <div class="column">
+    <div class="column">
+  
+      <mat-card>
+        <div class="title">Proposal details</div>
+  
+        <mat-form-field class="full-width">
+          <input matInput #title placeholder="Proposal's title" formControlName="title">
+          <mat-hint align="end">{{ title.value?.length || 0 }}/50</mat-hint>
+        </mat-form-field>
+  
+        <mat-form-field class="full-width">
+          <textarea matInput #description rows="25" placeholder="Description" formControlName="description"></textarea>
+          <mat-hint align="end">{{ description.value?.length || 0 }}/2000</mat-hint>
+        </mat-form-field>
+  
+        <p class="widget-help">
+          Objectively describe your proposal in detail; explain what to change, how to do it and why.
+        </p>
+      </mat-card>
+      
+      <!-- <mat-card>
+        <div class="title TO_DO">Voting period</div>
+        <p>
+          Specify when will the proposal be active for voting:
+        </p>
+        <div class="voting-period">
+          <!- TODO: populate the "voting-starts" input with: <current block> + 2000 (~ 3 days in future) ->
+          <!- TODO: implement "min" attribe which should be equal to current block (= can't submit new proposal retroactively) ->
+          <mat-form-field class="half-width">
+            <input matInput type="number" placeholder="Voting starts on block #" formControlName="voting-starts">
+          </mat-form-field>
+          <mat-form-field class="half-width voting-length" floatPlaceholder="never">
+            <mat-select placeholder="Voting period">
+              <mat-option value="9500">9500 blocks (~ 2 weeks)</mat-option>
+              <mat-option value="20000">20000 blocks (~ 1 month)</mat-option>
+              <mat-option value="40000">40000 blocks (~ 2 months)</mat-option>
+              <mat-option value="60000">60000 blocks (~ 3 months)</mat-option>
+            </mat-select>
+          </mat-form-field>
+        </div>
+        <p class="widget-help">
+          Note: 1 day equals to approx. 670 blocks. Current block: <strong class="TO_DO">XXXXXX</strong>
+        </p>
+      </mat-card> -->
+  
+    </div><!-- .column -->
     
-    <mat-card>
-      <div class="title">
-        Voting options
-        <button [disabled]="proposalFormGroup.controls.options.length >= 5" (click)="addNewInputField()" mat-button color="basic" class="small">
-          <!-- TODO: allow max of 5 options total -->
-          <mat-icon fontSet="partIcon" fontIcon="part-circle-plus"></mat-icon>
-          Add new option
-        </button>
-      </div>
-
-      <!-- voting options -->
-      <div formArrayName="options">
-        <div class="voting item" [formGroupName]="i"
-        *ngFor="let option of proposalFormGroup.controls.options.controls; let i = index">
-          <span class="no">{{i+1}}</span>
+  
+    <div class="column">
+      
+      <mat-card>
+        <div class="title">
+          Voting options
+          <button [disabled]="proposalFormGroup.controls.options.length >= 5" (click)="addNewInputField()" mat-button color="basic" class="small">
+            <!-- TODO: allow max of 5 options total -->
+            <mat-icon fontSet="partIcon" fontIcon="part-circle-plus"></mat-icon>
+            Add new option
+          </button>
+        </div>
+  
+        <!-- voting options -->
+        <div formArrayName="options">
+          <div class="voting item" [formGroupName]="i"
+          *ngFor="let option of proposalFormGroup.controls.options.controls; let i = index">
+            <span class="no">{{i+1}}</span>
+            <div class="content">
+              <mat-form-field class="full-width">
+                <input matInput placeholder="Option #{{i+1}}" formControlName="option">
+              </mat-form-field>
+            </div>
+  
+            <!-- remove button only visible from 3rd option -->
+            <div class="remove-option" *ngIf="i > 1">
+              <button (click)="removeInputField(i)" mat-button class="small" color="warn" matTooltip="Remove option" matTooltipPosition="before">
+                <mat-icon fontSet="partIcon" fontIcon="part-circle-remove"></mat-icon>
+              </button>
+            </div>
+          </div>
+        </div>
+        <!-- voting options -->
+  
+        <p class="widget-help">
+          Add a minimum of 2 voting options for your proposal. In this case, less is usually more. As such, we recommend a maximum of 5 voting options to be added.
+        </p>
+      </mat-card>
+  
+      <!-- <mat-card [formGroup]="infoFormGroup">
+        <div class="title">
+          Contact information <small>(optional)</small>
+          <button mat-button color="basic" class="small TO_DO">
+            <mat-icon fontSet="partIcon" fontIcon="part-person-add"></mat-icon>
+            Add contributor
+          </button>
+        </div>
+  
+        <div class="author item TO_DO">
+          <span class="no">1</span>
           <div class="content">
             <mat-form-field class="full-width">
-              <input matInput placeholder="Option #{{i+1}}" formControlName="option">
+              <input matInput placeholder="Your name/nickname" formControlName="nickname">
+            </mat-form-field>
+            <mat-form-field class="full-width">
+              <input matInput placeholder="Your Riot/Discord/Github username or an email address" formControlName="email">
             </mat-form-field>
           </div>
-
-          <!-- remove button only visible from 3rd option -->
-          <div class="remove-option" *ngIf="i > 1">
-            <button (click)="removeInputField(i)" mat-button class="small" color="warn" matTooltip="Remove option" matTooltipPosition="before">
-              <mat-icon fontSet="partIcon" fontIcon="part-circle-remove"></mat-icon>
-            </button>
-          </div>
         </div>
-      </div>
-      <!-- voting options -->
-
-      <p class="widget-help">
-        Add a minimum of 2 voting options for your proposal. In this case, less is usually more. As such, we recommend a maximum of 5 voting options to be added.
-      </p>
-    </mat-card>
-
-    <!-- <mat-card [formGroup]="infoFormGroup">
-      <div class="title">
-        Contact information <small>(optional)</small>
-        <button mat-button color="basic" class="small to-do">
-          <mat-icon fontSet="partIcon" fontIcon="part-person-add"></mat-icon>
-          Add contributor
-        </button>
-      </div>
-
-      <div class="author item to-do">
-        <span class="no">1</span>
-        <div class="content">
-          <mat-form-field class="full-width">
-            <input matInput placeholder="Your name/nickname" formControlName="nickname">
-          </mat-form-field>
-          <mat-form-field class="full-width">
-            <input matInput placeholder="Your Riot/Discord/Github username or an email address" formControlName="email">
-          </mat-form-field>
-        </div>
-      </div>
-
-      <!- FIXME: when clicked on [Add countributor] button, add these: ->
-      <!-div class="author item">
-        <span class="no">2</span>
-        <div class="content">
-          <mat-form-field class="full-width">
-            <input matInput placeholder="Contributor's name/nickname" formControlName="?????">
-          </mat-form-field>
-          <mat-form-field class="full-width">
-            <input matInput placeholder="Contibutor's Riot/Discord/Github username or an email address" formControlName="?????">
-          </mat-form-field>
-        </div>
-      </div->
-
-      <p class="widget-help">
-        Including your contact information is optional, but it can help when discussing submitted proposals. For example, users might have unanswered questions or improvements regarding your proposal.
-      </p>
-    </mat-card> -->
-
-    <mat-card class="terms">
-      <div class="title">Terms &amp; Conditions</div>
-      <ul>
-        <li>Proposal fee costs depends on the content size of the Proposal</li>
-        <li>Fees are non-refundable</li>
-        <li>Fees are distributed to network staking nodes</li>
-        <li>Voting results do not represent any form of finality</li>
-        <li>Proposals may still be denied even though they were voted in favour of, and vice versa</li>
-      </ul>
-      <mat-checkbox (change)="isTnCAccepted = !isTnCAccepted">Yes, I understand &amp; agree</mat-checkbox>
-    </mat-card>
-
-  </div>
-
   
+        <!- FIXME: when clicked on [Add countributor] button, add these: ->
+        <!-div class="author item">
+          <span class="no">2</span>
+          <div class="content">
+            <mat-form-field class="full-width">
+              <input matInput placeholder="Contributor's name/nickname" formControlName="?????">
+            </mat-form-field>
+            <mat-form-field class="full-width">
+              <input matInput placeholder="Contibutor's Riot/Discord/Github username or an email address" formControlName="?????">
+            </mat-form-field>
+          </div>
+        </div->
+  
+        <p class="widget-help">
+          Including your contact information is optional, but it can help when discussing submitted proposals. For example, users might have unanswered questions or improvements regarding your proposal.
+        </p>
+      </mat-card> -->
+  
+      <mat-card class="terms">
+        <div class="title">Terms &amp; Conditions</div>
+        <ul>
+          <li>Proposal fee costs depends on the content size of the Proposal</li>
+          <li>Fees are non-refundable</li>
+          <li>Fees are distributed to network staking nodes</li>
+          <li>Voting results do not represent any form of finality</li>
+          <li>Proposals may still be denied even though they were voted in favour of, and vice versa</li>
+        </ul>
+        <mat-checkbox (change)="isTnCAccepted = !isTnCAccepted">Yes, I understand &amp; agree</mat-checkbox>
+      </mat-card>
+  
+    </div>
+  
+    
+  </div><!-- .container-block -->
+
 </div><!-- .container-block -->
+
 
 
 <div class="action-buttons" fxLayout fxLayoutAlign="space-between center">

--- a/src/app/wallet/proposals/add-proposal/add-proposal.component.scss
+++ b/src/app/wallet/proposals/add-proposal/add-proposal.component.scss
@@ -2,14 +2,9 @@
 
 // ------ LAYOUT ------ //
 
-.container-block {
+.row {
   position: relative;
-  //margin-top: $header-main-height;
-  padding: $padding;
   display: flex;
-  @include break(l) {
-    padding: 45px $padding-l;
-  }
 }
 
 .column {

--- a/src/app/wallet/wallet/address-book/address-book.component.html
+++ b/src/app/wallet/wallet/address-book/address-book.component.html
@@ -1,18 +1,21 @@
 <div class="address-book container-block without-tab-bar">
 
-  <div class="page-intro">
-    <button mat-button class="intro-toggle small">
-      <mat-icon fontSet="partIcon" fontIcon="part-cross"></mat-icon>
-      <mat-icon fontSet="partIcon" fontIcon="part-circle-question"></mat-icon>
+  <div class="page-intro" [ngClass]="{ 'inactive': !introDisplayed }">
+    <button mat-button class="intro-toggle small"
+            (click)="introDisplayed = !introDisplayed"
+            matTooltip="{{ (introDisplayed) ? 'Hide intro': 'Show help' }}" matTooltipPosition="before">
+      <mat-icon fontSet="partIcon" fontIcon="part-{{ (introDisplayed) ? 'cross': 'circle-question' }}"></mat-icon>
     </button>
     <h1>Address Book</h1>
-    <p>
-      Address Book is your personal collection of saved addresses belonging to other parties.
-    </p>
-    <p class="widget-help">
-      Note that it is recommended that you mostly save Private addresses (if possible).<br>
-      Re-using the same Public addresses increases transaction traceability, which results in loss of privacy both for you and the other party.
-    </p>
+    <div class="content" *ngIf="introDisplayed">
+      <p>
+        Address Book is your personal collection of saved addresses belonging to other parties.
+      </p>
+      <p class="widget-help">
+        Note that it is recommended that you mostly save Private addresses (if possible).<br>
+        Re-using the same Public addresses increases transaction traceability, which results in loss of privacy both for you and the other party.
+      </p>
+    </div>
   </div><!-- .page-intro -->
 
   <div class="filter">

--- a/src/app/wallet/wallet/address-book/address-book.component.html
+++ b/src/app/wallet/wallet/address-book/address-book.component.html
@@ -1,13 +1,14 @@
 <div class="address-book container-block without-tab-bar">
 
-  <div class="page-intro" [ngClass]="{ 'inactive': !introDisplayed }">
-    <button mat-button class="intro-toggle small"
+  <!-- PR #1267 | PD-483: implement toggle-able page title description: -->
+  <div class="page-intro"><!-- [ngClass]="{ 'inactive': !introDisplayed }" -->
+    <!--button mat-button class="intro-toggle small"
             (click)="introDisplayed = !introDisplayed"
             matTooltip="{{ (introDisplayed) ? 'Hide intro': 'Show help' }}" matTooltipPosition="before">
       <mat-icon fontSet="partIcon" fontIcon="part-{{ (introDisplayed) ? 'cross': 'circle-question' }}"></mat-icon>
-    </button>
+    </button-->
     <h1>Address Book</h1>
-    <div class="content" *ngIf="introDisplayed">
+    <div class="content"><!-- *ngIf="introDisplayed" -->
       <p>
         Address Book is your personal collection of saved addresses belonging to other parties.
       </p>

--- a/src/app/wallet/wallet/address-book/address-book.component.html
+++ b/src/app/wallet/wallet/address-book/address-book.component.html
@@ -1,5 +1,20 @@
 <div class="address-book container-block without-tab-bar">
 
+  <div class="page-intro">
+    <button mat-button class="intro-toggle small">
+      <mat-icon fontSet="partIcon" fontIcon="part-cross"></mat-icon>
+      <mat-icon fontSet="partIcon" fontIcon="part-circle-question"></mat-icon>
+    </button>
+    <h1>Address Book</h1>
+    <p>
+      Address Book is your personal collection of saved addresses belonging to other parties.
+    </p>
+    <p class="widget-help">
+      Note that it is recommended that you mostly save Private addresses (if possible).<br>
+      Re-using the same Public addresses increases transaction traceability, which results in loss of privacy both for you and the other party.
+    </p>
+  </div><!-- .page-intro -->
+
   <div class="filter">
 
     <div class="add-address">
@@ -32,10 +47,6 @@
         </mat-select>
       </mat-card>
     </div><!-- .search-sorting -->
-
-    <p class="widget-help">
-      Address Book is your personal collection of saved addresses belonging to other parties. Kindly note that as re-using the same address for more than one transaction increases traceability &ndash; it is recommended that you mostly save private addresses (if possible) so that both parties’ identities remain private.
-    </p>
 
   </div><!-- .filter -->
 

--- a/src/app/wallet/wallet/address-book/address-book.component.ts
+++ b/src/app/wallet/wallet/address-book/address-book.component.ts
@@ -22,6 +22,9 @@ export class AddressBookComponent {
     this.addressHelper = new AddressHelper();
   }
 
+  // UI logic
+  introDisplayed: boolean = true; // display full page title with description
+
   openNewAddress(): void {
     const dialogRef = this.dialog.open(NewAddressModalComponent);
   }

--- a/src/app/wallet/wallet/address-book/address-book.component.ts
+++ b/src/app/wallet/wallet/address-book/address-book.component.ts
@@ -14,7 +14,7 @@ export class AddressBookComponent {
 
   log: any = Log.create('address-book.component');
   // UI logic
-  introDisplayed: boolean = true; // display full page title with description
+  // introDisplayed: boolean = true; // PR #1267 | PD-483: display full page title with description
 
   public query: string;
   public filter: RegExp;

--- a/src/app/wallet/wallet/address-book/address-book.component.ts
+++ b/src/app/wallet/wallet/address-book/address-book.component.ts
@@ -13,6 +13,8 @@ import { AddressHelper } from '../../../core/util/utils';
 export class AddressBookComponent {
 
   log: any = Log.create('address-book.component');
+  // UI logic
+  introDisplayed: boolean = true; // display full page title with description
 
   public query: string;
   public filter: RegExp;
@@ -21,9 +23,6 @@ export class AddressBookComponent {
     private dialog: MatDialog) {
     this.addressHelper = new AddressHelper();
   }
-
-  // UI logic
-  introDisplayed: boolean = true; // display full page title with description
 
   openNewAddress(): void {
     const dialogRef = this.dialog.open(NewAddressModalComponent);

--- a/src/assets/_config.scss
+++ b/src/assets/_config.scss
@@ -70,6 +70,12 @@ $break-xhd: 2200px;
     http://thesassway.com/intermediate/understanding-placeholder-selectors
 \* ------------------------------- */
 
+// ------ 3.1. TYPOGRAPHY ------ //
+
+%lighter { // "grey" text, formerly "help descriptions"
+  opacity: 0.55;
+}
+
 %subtitle { // section titles / H2's
   font-size: 14px;
   font-family: $font;
@@ -84,6 +90,9 @@ $break-xhd: 2200px;
   font-weight: 700;
   font-size: 15px;
 }
+
+
+// ------ 3.2. UI ELEMENTS ------ //
 
 %tag { // notification tags - e.g. in tabs: Orders [3]
   @extend %tfx;
@@ -102,6 +111,9 @@ $break-xhd: 2200px;
   border-top: 1px solid #15191a;
   box-shadow: 0 1px 0 #333 inset;
 }
+
+
+// ------ 3.3. HELPER & MISC ------ //
 
 // enable/disable text selection
 %disable-select {

--- a/src/assets/scss/_mixins.scss
+++ b/src/assets/scss/_mixins.scss
@@ -34,5 +34,5 @@
 // @include gradient (<top-color>, <bottom-color>);
 
 @mixin gradient($top, $bottom) {
-  background: linear-gradient(to bottom, $top 0%,$bottom 100%);
+  background: linear-gradient(to bottom, $top 0%, $bottom 100%);
 }

--- a/src/assets/scss/_mixins.scss
+++ b/src/assets/scss/_mixins.scss
@@ -27,3 +27,12 @@
 @mixin break-from($size) {
   @media only screen and (min-width: $size) { @content; }
 }
+
+
+// ------ GRADIENTS ------ //
+
+// @include gradient (<top-color>, <bottom-color>);
+
+@mixin gradient($top, $bottom) {
+  background: linear-gradient(to bottom, $top 0%,$bottom 100%);
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -136,10 +136,10 @@ body {
 // descriptive page titles
 .page-intro {
   @include gradient(rgba($color-white, 0.7), $bg);
-  margin: (-$padding) (-$padding) 0 (-$padding);
+  margin: (-$padding) (-$padding) 0;
   padding: $padding;
   @include break(l) {
-    margin: (-$padding-l) (-$padding-l) 0 (-$padding-l);
+    margin: (-$padding-l) (-$padding-l) 0;
     padding: $padding-l;
   }
   .intro-toggle {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -143,10 +143,17 @@ body {
     padding: $padding-l;
   }
   .intro-toggle {
+    @extend %lighter;
     float: right;
+    .mat-icon {
+      margin: 0;
+    }
   }
   h1 {
-    margin-top: 0;
+    margin: 0;
+  }
+  .content {
+    margin-top: 16px;
   }
   .widget-help {
     margin-bottom: 0;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -21,6 +21,7 @@ What you can't find here will be probably in `/src/assets/scss/material-componen
       2.2. Modifiers
       2.3. Tab/control bars
       2.4. Filters (sidebars)
+      2.5. Page intros (help titles)
     3. UI elements
       3.1. Buttons
       3.2. Addresses
@@ -45,7 +46,10 @@ body {
   @extend %disable-select;
   font-family: $font;
   background-color: $bg;
-  font-size: 12px;
+  font-size: 13px;
+  @include break(l) {
+    font-size: 14px;
+  }
 }
 
 
@@ -123,6 +127,29 @@ body {
   float: left;
   .without-tab-bar & {
     top: ($header-main-height + $padding);
+  }
+}
+
+
+// ------ 2.5. PAGE INTROS ------ //
+
+// descriptive page titles
+.page-intro {
+  @include gradient(rgba($color-white, 0.7), $bg);
+  margin: (-$padding) (-$padding) 0 (-$padding);
+  padding: $padding;
+  @include break(l) {
+    margin: (-$padding-l) (-$padding-l) 0 (-$padding-l);
+    padding: $padding-l;
+  }
+  .intro-toggle {
+    float: right;
+  }
+  h1 {
+    margin-top: 0;
+  }
+  .widget-help {
+    margin-bottom: 0;
   }
 }
 
@@ -263,6 +290,11 @@ body {
     4. TYPOGRAPHY
 \* ------------------------------- */
 
+h1 {
+  font-weight: 500;
+}
+
+
 // ------ 4.1. PAGE SUBTITLES ------ //
 
 .mat-list { // 'H2' subtitles in pages (e.g. '(un)used addresses' in Receive
@@ -288,9 +320,9 @@ body {
 
 // Help descriptions
 .widget-help {
-  color: $text-muted;
-  font-size: 12px;
-  line-height: 1.45;
+  @extend %lighter;
+  font-size: 93%;
+  line-height: 1.5;
   margin-bottom: 25px;
   cursor: help;
 }


### PR DESCRIPTION
![page-intros](https://user-images.githubusercontent.com/1965795/48720404-ea122880-ec1f-11e8-9b82-d8ca0bc2b080.gif)

More info on https://particl.atlassian.net/browse/PD-483

- new "page titles"/intros with toggle-able help description
- so far only "dumb" (we implement saving of toggle state for each page)
- a requirement for Private Markets (separated, so we can use it before merge of PM)
- more pages will be added later (now only on Address Book & New Proposal)
