### PR TITLE
GFX: Listing detail (redesign)

### DIFF
--- a/src/app/market/listings/preview-listing/preview-listing.component.html
+++ b/src/app/market/listings/preview-listing/preview-listing.component.html
@@ -49,11 +49,9 @@
         </div>
       </div><!-- .pricing -->
 
-      <div class="summary description">
-        <p>
-          {{ data?.listing?.shortDescription }}
-        </p>
-      </div>
+      <p class="summary description">
+        {{ data?.listing?.shortDescription }}
+      </p>
 
       <table class="meta">
         <tr>
@@ -106,33 +104,26 @@
     </mat-tab-group><!-- .listing-tabs -->
 
     <div class="tab-content details" *ngIf="tabLabels[selectedTab] == 'details'">
-      <div class="detailed description">
-        <p>{{ data?.listing?.longDescription }}</p>
-      </div>
+      <p class="detailed description">{{ data?.listing?.longDescription }}</p>
     </div><!-- .tab-content.details -->
 
     <div class="tab-content shipping" *ngIf="tabLabels[selectedTab] == 'shipping'">
       <table class="shipping-escrow">
         <thead>
           <tr>
-            <th></th>
-            <th>Worldwide</th>
-            <th [matTooltip]="countryListService?.getCountryByRegion(data?.listing?.country)?.name">
-              Local in {{ data?.listing?.country }}
-            </th>
+            <th>Shipping to</th>
+            <th>Shipping</th>
+            <th>Escrow</th>
+            <th>Total needed for order</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <th><strong>Shipping</strong></th>
-            <td>
-              <span class="part price">
-                <strong>{{ data?.listing?.internationalShippingPrice.getAmount() }}</strong> <small class="currency">PART</small>
-              </span>
-              <span class="fiat price">
-                &asymp; 0.41 <small class="currency">EUR</small>
-              </span>
-            </td>
+            <th>
+              {{ countryListService?.getCountryByRegion(data?.listing?.country)?.name }}
+              <small>Shipping carrier</small>
+            </th>
+            <!-- domestic shipping -->
             <td>
               <span class="part price">
                 <strong>{{ data?.listing?.domesticShippingPrice.getAmount() }}</strong> <small class="currency">PART</small>
@@ -141,22 +132,8 @@
                 &asymp; 0.41 <small class="currency">EUR</small>
               </span>
             </td>
-          </tr>
-          <tr>
-            <th>
-              <strong>Escrow</strong><br>
-              (refunded upon delivery)
-            </th>
+            <!-- domestic escrow -->
             <td>
-              <span class="part price">
-                <strong>{{ data?.listing?.escrowPriceInternational?.getAmount() }}</strong> <small class="currency">PART</small>
-              </span>
-              <span class="fiat price">
-                &asymp; 0.41 <small class="currency">EUR</small>
-              </span>
-            </td>
-            <td>
-              <!-- FIXME: "escrow for local (not international)" needs to be implemented: -->
               <span class="part price">
                 <strong>{{ data?.listing?.escrowPriceDomestic?.getAmount() }}</strong> <small class="currency">PART</small>
               </span>
@@ -164,21 +141,7 @@
                 &asymp; 0.41 <small class="currency">EUR</small>
               </span>
             </td>
-          </tr>
-          <tr>
-            <th>
-              <strong>Total needed for order</strong><br>
-              (incl. refundable Escrow)
-            </th>
-            <!-- TODO: price + shipping + escrow -->
-            <td>
-              <span class="part price">
-                <strong>{{data?.listing?.totalAmountInternaltional?.getAmount()}}</strong> <small class="currency">PART</small>
-              </span>
-              <span class="fiat price">
-                &asymp; 0.41 <small class="currency">EUR</small>
-              </span>
-            </td>
+            <!-- domestic total -->
             <td>
               <span class="part price">
                 <strong>{{data?.listing?.totalAmountDomestic?.getAmount()}}</strong> <small class="currency">PART</small>
@@ -188,12 +151,59 @@
               </span>
             </td>
           </tr>
+          <tr>
+            <th>
+              Worldwide 
+              <small>Shipping carrier</small>
+            </th>
+            <!-- international shipping -->
+            <td>
+              <span class="part price">
+                <strong>{{ data?.listing?.internationalShippingPrice.getAmount() }}</strong> <small class="currency">PART</small>
+              </span>
+              <span class="fiat price">
+                &asymp; 0.41 <small class="currency">EUR</small>
+              </span>
+            </td>
+            <!-- international escrow -->
+            <td>
+              <span class="part price">
+                <strong>{{ data?.listing?.escrowPriceInternational?.getAmount() }}</strong> <small class="currency">PART</small>
+              </span>
+              <span class="fiat price">
+                &asymp; 0.41 <small class="currency">EUR</small>
+              </span>
+            </td>
+            <!-- international total -->
+            <td>
+              <span class="part price">
+                <strong>{{data?.listing?.totalAmountInternaltional?.getAmount()}}</strong> <small class="currency">PART</small>
+              </span>
+              <span class="fiat price">
+                &asymp; 0.41 <small class="currency">EUR</small>
+              </span>
+            </td>
+          </tr>
+          <tr class="help-text">
+            <td></td>
+            <td>
+              <small>Shipping price for 1 item</small>
+            </td>
+            <td>
+              <small>Security deposit (100% of order value) needed for this trade &ndash; it will be refunded after order is completed and delivered</small>
+            </td>
+            <td>
+              <small>Amount of funds needed in total for this trade (incl. the refundable escrow)</small>
+            </td>
+          </tr>
         </tbody>
       </table><!-- .shipping-escrow -->
-    </div>
+    </div><!-- .tab-content.shipping-->
     
     <div class="tab-content comments" *ngIf="tabLabels[selectedTab] == 'comments'">
-      Comments
+      <div class="no-results">
+        Comments coming soon™
+      </div>
     </div>
   </div><!-- .product-details -->
 

--- a/src/app/market/listings/preview-listing/preview-listing.component.html
+++ b/src/app/market/listings/preview-listing/preview-listing.component.html
@@ -1,16 +1,16 @@
-<div mat-dialog-title>
+<!--div mat-dialog-title>
   {{data?.listing?.title}}
   <span class="category">
     in {{data?.listing?.category.name}}
   </span>
-</div>
+</div-->
 
 <button class="small-close-button pull-right" (click)="dialogClose()">
   <mat-icon fontSet="partIcon" fontIcon="part-circle-remove"></mat-icon>
 </button>
 
 <div mat-dialog-content class="dialog-content">
-  <div class="product" fxLayout="row">
+  <div class="product-summary" fxLayout="row">
 
     <div class="product-gallery" fxFlex="1 1 450px">
       <div class="gallery-carousel">
@@ -34,7 +34,9 @@
 
     <div class="product-info" fxFlex="1 1 100%">
 
-      <div class="pricing" fxLayout fxLayoutAlign="space-between flex-start">
+      <h1>{{ data?.listing?.title }}</h1>
+
+      <div class="pricing">
 
         <div class="item price">
           <div class="title">Price</div>
@@ -45,6 +47,12 @@
           <div class="value fiat">
             <span class="fiat">~ {{price?.usd}} xx EUR</span>
           </div>
+        </div>
+
+        <div class="summary description">
+          <p>
+            {{ data?.listing?.shortDescription }}
+          </p>
         </div>
 
         <div class="item category">
@@ -65,108 +73,108 @@
 
       </div><!-- .pricing -->
 
-      <mat-tab-group class="listing-tabs" (selectChange)="changeTab($event.index)">
-        <mat-tab label="Details"></mat-tab>
-        <mat-tab label="Comments"></mat-tab>
-      </mat-tab-group><!-- .listing-tabs -->
-
-      <div class="tab-content details" *ngIf="tabLabels[selectedTab] == 'details'">
-        <div class="summary description">
-          <p>
-            {{ data?.listing?.shortDescription }}
-          </p>
-        </div>
-        <div class="detailed description">
-          <p>
-            {{ data?.listing?.longDescription }}
-          </p>
-        </div>
-        <table class="shipping-escrow">
-          <thead>
-            <tr>
-              <th></th>
-              <th>Worldwide</th>
-              <th [matTooltip]="countryListService?.getCountryByRegion(data?.listing?.country)?.name">
-                Local in {{ data?.listing?.country }}
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th><strong>Shipping</strong></th>
-              <td>
-                <span class="part price">
-                  <strong>{{ data?.listing?.internationalShippingPrice.getAmount() }}</strong> <small class="currency">PART</small>
-                </span>
-                <span class="fiat price">
-                  &asymp; 0.41 <small class="currency">EUR</small>
-                </span>
-              </td>
-              <td>
-                <span class="part price">
-                  <strong>{{ data?.listing?.domesticShippingPrice.getAmount() }}</strong> <small class="currency">PART</small>
-                </span>
-                <span class="fiat price">
-                  &asymp; 0.41 <small class="currency">EUR</small>
-                </span>
-              </td>
-            </tr>
-            <tr>
-              <th>
-                <strong>Escrow</strong><br>
-                (refunded upon delivery)
-              </th>
-              <td>
-                <span class="part price">
-                  <strong>{{ data?.listing?.escrowPriceInternational?.getAmount() }}</strong> <small class="currency">PART</small>
-                </span>
-                <span class="fiat price">
-                  &asymp; 0.41 <small class="currency">EUR</small>
-                </span>
-              </td>
-              <td>
-                <!-- FIXME: "escrow for local (not international)" needs to be implemented: -->
-                <span class="part price">
-                  <strong>{{ data?.listing?.escrowPriceDomestic?.getAmount() }}</strong> <small class="currency">PART</small>
-                </span>
-                <span class="fiat price">
-                  &asymp; 0.41 <small class="currency">EUR</small>
-                </span>
-              </td>
-            </tr>
-            <tr>
-              <th>
-                <strong>Total needed for order</strong><br>
-                (incl. refundable Escrow)
-              </th>
-              <!-- TODO: price + shipping + escrow -->
-              <td>
-                <span class="part price">
-                  <strong>{{data?.listing?.totalAmountInternaltional?.getAmount()}}</strong> <small class="currency">PART</small>
-                </span>
-                <span class="fiat price">
-                  &asymp; 0.41 <small class="currency">EUR</small>
-                </span>
-              </td>
-              <td>
-                <span class="part price">
-                  <strong>{{data?.listing?.totalAmountDomestic?.getAmount()}}</strong> <small class="currency">PART</small>
-                </span>
-                <span class="fiat price">
-                  &asymp; 0.41 <small class="currency">EUR</small>
-                </span>
-              </td>
-            </tr>
-          </tbody>
-        </table><!-- .shipping-escrow -->
-      </div><!-- .tab-content.details -->
-      
-      <div class="tab-content comments" *ngIf="tabLabels[selectedTab] == 'comments'">
-        Comments
-      </div>
-
     </div><!-- .product-info -->
-  </div><!-- .product -->
+  </div><!-- .product-summary -->
+
+  <div class="product-details">
+    <mat-tab-group class="listing-tabs" (selectChange)="changeTab($event.index)">
+      <mat-tab label="Details"></mat-tab>
+      <mat-tab label="Shipping &amp; Escrow"></mat-tab>
+      <mat-tab label="Comments"></mat-tab>
+    </mat-tab-group><!-- .listing-tabs -->
+
+    <div class="tab-content details" *ngIf="tabLabels[selectedTab] == 'details'">
+      <div class="detailed description">
+        <p>{{ data?.listing?.longDescription }}</p>
+      </div>
+    </div><!-- .tab-content.details -->
+    
+    <div class="tab-content shipping" *ngIf="tabLabels[selectedTab] == 'shipping'">
+      <table class="shipping-escrow">
+        <thead>
+          <tr>
+            <th></th>
+            <th>Worldwide</th>
+            <th [matTooltip]="countryListService?.getCountryByRegion(data?.listing?.country)?.name">
+              Local in {{ data?.listing?.country }}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th><strong>Shipping</strong></th>
+            <td>
+              <span class="part price">
+                <strong>{{ data?.listing?.internationalShippingPrice.getAmount() }}</strong> <small class="currency">PART</small>
+              </span>
+              <span class="fiat price">
+                &asymp; 0.41 <small class="currency">EUR</small>
+              </span>
+            </td>
+            <td>
+              <span class="part price">
+                <strong>{{ data?.listing?.domesticShippingPrice.getAmount() }}</strong> <small class="currency">PART</small>
+              </span>
+              <span class="fiat price">
+                &asymp; 0.41 <small class="currency">EUR</small>
+              </span>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              <strong>Escrow</strong><br>
+              (refunded upon delivery)
+            </th>
+            <td>
+              <span class="part price">
+                <strong>{{ data?.listing?.escrowPriceInternational?.getAmount() }}</strong> <small class="currency">PART</small>
+              </span>
+              <span class="fiat price">
+                &asymp; 0.41 <small class="currency">EUR</small>
+              </span>
+            </td>
+            <td>
+              <!-- FIXME: "escrow for local (not international)" needs to be implemented: -->
+              <span class="part price">
+                <strong>{{ data?.listing?.escrowPriceDomestic?.getAmount() }}</strong> <small class="currency">PART</small>
+              </span>
+              <span class="fiat price">
+                &asymp; 0.41 <small class="currency">EUR</small>
+              </span>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              <strong>Total needed for order</strong><br>
+              (incl. refundable Escrow)
+            </th>
+            <!-- TODO: price + shipping + escrow -->
+            <td>
+              <span class="part price">
+                <strong>{{data?.listing?.totalAmountInternaltional?.getAmount()}}</strong> <small class="currency">PART</small>
+              </span>
+              <span class="fiat price">
+                &asymp; 0.41 <small class="currency">EUR</small>
+              </span>
+            </td>
+            <td>
+              <span class="part price">
+                <strong>{{data?.listing?.totalAmountDomestic?.getAmount()}}</strong> <small class="currency">PART</small>
+              </span>
+              <span class="fiat price">
+                &asymp; 0.41 <small class="currency">EUR</small>
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table><!-- .shipping-escrow -->
+    </div>
+    
+    <div class="tab-content comments" *ngIf="tabLabels[selectedTab] == 'comments'">
+      Comments
+    </div>
+  </div><!-- .product-details -->
+
 </div><!-- .dialog-content -->
 
 

--- a/src/app/market/listings/preview-listing/preview-listing.component.html
+++ b/src/app/market/listings/preview-listing/preview-listing.component.html
@@ -22,7 +22,7 @@
           *ngIf="data?.listing?.imageCollection?.imageItems?.length"
           gallerize
           [gestures]="false"
-          [style.height.px]="417"
+          [style.height.px]="380"
           [style.width.px]="450"
           [thumbWidth]= "80"
           [thumbHeight]="80"
@@ -55,21 +55,45 @@
           </p>
         </div>
 
-        <div class="item category">
-          <div class="title">Category</div>
-          <div class="value">
-            <mat-icon fontSet="partIcon" fontIcon="part-label"></mat-icon>
-            {{ data?.listing?.category.name }}
-          </div>
-        </div>
-
-        <div class="item seller-country">
-          <div class="title">Sold from</div>
-          <div class="value" [matTooltip]="countryListService?.getCountryByRegion(data?.listing?.country)?.name">
-            <mat-icon fontSet="partIcon" fontIcon="part-globe"></mat-icon>
-            {{ data?.listing?.country }}
-          </div>
-        </div>
+        <table class="meta">
+          <tr>
+            <th class="title">
+              <mat-icon fontSet="partIcon" fontIcon="part-truck"></mat-icon>
+              Shipping
+            </th>
+            <td class="value">
+              {{ data?.listing?.domesticShippingPrice.getAmount() }} &ndash; {{ data?.listing?.internationalShippingPrice.getAmount() }} <small>PART</small>
+            </td>
+          </tr>
+          <tr>
+            <th class="title">
+              <mat-icon fontSet="partIcon" fontIcon="part-label"></mat-icon>
+              Category
+            </th>
+            <td class="value">
+              {{ data?.listing?.category.name }}
+            </td>
+          </tr>
+          <tr>
+            <th class="title">
+              <mat-icon fontSet="partIcon" fontIcon="part-globe"></mat-icon>
+              Sold from
+            </th>
+            <td class="value">
+              {{ countryListService?.getCountryByRegion(data?.listing?.country)?.name }}
+              ({{ data?.listing?.country }})
+            </td>
+          </tr>
+          <tr>
+            <th class="title">
+              <mat-icon fontSet="partIcon" fontIcon="part-date"></mat-icon>
+              Date added
+            </th>
+            <td class="value">
+              {{ data?.listing?.createdAt }}
+            </td>
+          </tr>
+        </table>
 
       </div><!-- .pricing -->
 
@@ -88,7 +112,7 @@
         <p>{{ data?.listing?.longDescription }}</p>
       </div>
     </div><!-- .tab-content.details -->
-    
+
     <div class="tab-content shipping" *ngIf="tabLabels[selectedTab] == 'shipping'">
       <table class="shipping-escrow">
         <thead>

--- a/src/app/market/listings/preview-listing/preview-listing.component.html
+++ b/src/app/market/listings/preview-listing/preview-listing.component.html
@@ -65,96 +65,108 @@
 
       </div><!-- .pricing -->
 
-      <div class="summary description">
-        <p>
-          {{ data?.listing?.shortDescription }}
-        </p>
-      </div>
-      
-      <div class="detailed description">
-        <p>
-          {{ data?.listing?.longDescription }}
-        </p>
-      </div>
+      <mat-tab-group class="listing-tabs">
 
-      <table class="shipping-escrow">
-        <thead>
-          <tr>
-            <th></th>
-            <th>Worldwide</th>
-            <th [matTooltip]="countryListService?.getCountryByRegion(data?.listing?.country)?.name">
-              Local in {{ data?.listing?.country }}
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th><strong>Shipping</strong></th>
-            <td>
-              <span class="part price">
-                <strong>{{ data?.listing?.internationalShippingPrice.getAmount() }}</strong> <small class="currency">PART</small>
-              </span>
-              <span class="fiat price">
-                &asymp; 0.41 <small class="currency">EUR</small>
-              </span>
-            </td>
-            <td>
-              <span class="part price">
-                <strong>{{ data?.listing?.domesticShippingPrice.getAmount() }}</strong> <small class="currency">PART</small>
-              </span>
-              <span class="fiat price">
-                &asymp; 0.41 <small class="currency">EUR</small>
-              </span>
-            </td>
-          </tr>
-          <tr>
-            <th>
-              <strong>Escrow</strong><br>
-              (refunded upon delivery)
-            </th>
-            <td>
-              <span class="part price">
-                <strong>{{ data?.listing?.escrowPriceInternational?.getAmount() }}</strong> <small class="currency">PART</small>
-              </span>
-              <span class="fiat price">
-                &asymp; 0.41 <small class="currency">EUR</small>
-              </span>
-            </td>
-            <td>
-              <!-- FIXME: "escrow for local (not international)" needs to be implemented: -->
-              <span class="part price">
-                <strong>{{ data?.listing?.escrowPriceDomestic?.getAmount() }}</strong> <small class="currency">PART</small>
-              </span>
-              <span class="fiat price">
-                &asymp; 0.41 <small class="currency">EUR</small>
-              </span>
-            </td>
-          </tr>
-          <tr>
-            <th>
-              <strong>Total needed for order</strong><br>
-              (incl. refundable Escrow)
-            </th>
-            <!-- TODO: price + shipping + escrow -->
-            <td>
-              <span class="part price">
-                <strong>{{data?.listing?.totalAmountInternaltional?.getAmount()}}</strong> <small class="currency">PART</small>
-              </span>
-              <span class="fiat price">
-                &asymp; 0.41 <small class="currency">EUR</small>
-              </span>
-            </td>
-            <td>
-              <span class="part price">
-                <strong>{{data?.listing?.totalAmountDomestic?.getAmount()}}</strong> <small class="currency">PART</small>
-              </span>
-              <span class="fiat price">
-                &asymp; 0.41 <small class="currency">EUR</small>
-              </span>
-            </td>
-          </tr>
-        </tbody>
-      </table><!-- .shipping-escrow -->
+        <mat-tab label="Details">
+          <div class="summary description">
+            <p>
+              {{ data?.listing?.shortDescription }}
+            </p>
+          </div>
+          <div class="detailed description">
+            <p>
+              {{ data?.listing?.longDescription }}
+            </p>
+          </div>
+          <table class="shipping-escrow">
+            <thead>
+              <tr>
+                <th></th>
+                <th>Worldwide</th>
+                <th [matTooltip]="countryListService?.getCountryByRegion(data?.listing?.country)?.name">
+                  Local in {{ data?.listing?.country }}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th><strong>Shipping</strong></th>
+                <td>
+                  <span class="part price">
+                    <strong>{{ data?.listing?.internationalShippingPrice.getAmount() }}</strong> <small class="currency">PART</small>
+                  </span>
+                  <span class="fiat price">
+                    &asymp; 0.41 <small class="currency">EUR</small>
+                  </span>
+                </td>
+                <td>
+                  <span class="part price">
+                    <strong>{{ data?.listing?.domesticShippingPrice.getAmount() }}</strong> <small class="currency">PART</small>
+                  </span>
+                  <span class="fiat price">
+                    &asymp; 0.41 <small class="currency">EUR</small>
+                  </span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <strong>Escrow</strong><br>
+                  (refunded upon delivery)
+                </th>
+                <td>
+                  <span class="part price">
+                    <strong>{{ data?.listing?.escrowPriceInternational?.getAmount() }}</strong> <small class="currency">PART</small>
+                  </span>
+                  <span class="fiat price">
+                    &asymp; 0.41 <small class="currency">EUR</small>
+                  </span>
+                </td>
+                <td>
+                  <!-- FIXME: "escrow for local (not international)" needs to be implemented: -->
+                  <span class="part price">
+                    <strong>{{ data?.listing?.escrowPriceDomestic?.getAmount() }}</strong> <small class="currency">PART</small>
+                  </span>
+                  <span class="fiat price">
+                    &asymp; 0.41 <small class="currency">EUR</small>
+                  </span>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <strong>Total needed for order</strong><br>
+                  (incl. refundable Escrow)
+                </th>
+                <!-- TODO: price + shipping + escrow -->
+                <td>
+                  <span class="part price">
+                    <strong>{{data?.listing?.totalAmountInternaltional?.getAmount()}}</strong> <small class="currency">PART</small>
+                  </span>
+                  <span class="fiat price">
+                    &asymp; 0.41 <small class="currency">EUR</small>
+                  </span>
+                </td>
+                <td>
+                  <span class="part price">
+                    <strong>{{data?.listing?.totalAmountDomestic?.getAmount()}}</strong> <small class="currency">PART</small>
+                  </span>
+                  <span class="fiat price">
+                    &asymp; 0.41 <small class="currency">EUR</small>
+                  </span>
+                </td>
+              </tr>
+            </tbody>
+          </table><!-- .shipping-escrow -->
+        </mat-tab><!-- details -->
+
+        <mat-tab label="Ratings">
+          ratings
+        </mat-tab><!-- ratings -->
+
+        <mat-tab label="Comments">
+          comments
+        </mat-tab><!-- comments -->
+
+      </mat-tab-group><!-- .listing-tabs -->
 
     </div><!-- .product-info -->
   </div><!-- .product -->

--- a/src/app/market/listings/preview-listing/preview-listing.component.html
+++ b/src/app/market/listings/preview-listing/preview-listing.component.html
@@ -205,15 +205,10 @@
 <mat-dialog-actions fxLayoutAlign="space-between center">
 
   <div class="left">
+
     <app-report *ngIf="!data?.listing?.isFlagged && !data?.listing?.isMine" [listing]="data?.listing" [from]="'preview'"></app-report>
-    <div class="date">
-      <strong class="title">Date added</strong> {{ data?.listing?.createdAt }}
-    </div>
-  </div>
 
-  <div class="center" *ngIf="data?.listing?.isFlagged">
-    <div class="reporting">
-
+    <div class="reporting" *ngIf="data?.listing?.isFlagged">
       <!-- Reported, not voted yet by user -->
       <div *ngIf="!data?.listing?.VoteDetails">
         <span class="title"><strong>Item reported</strong> as inappropriate, please vote:</span>
@@ -224,9 +219,8 @@
           <mat-icon fontSet="partIcon" fontIcon="part-thumb-down"></mat-icon>
         </button>
       </div>
-
       <!-- Reported & voted already -->
-      <div *ngIf="data?.listing?.VoteDetails">
+      <div *ngIf="data?.listing?.VoteDetails" class="voted">
         <p *ngIf="data?.listing?.VoteDetails?.isReported">
           <mat-icon fontSet="partIcon" fontIcon="part-flag" class="voted-icon"></mat-icon>
           Thanks for flagging this item as inappropriate
@@ -236,8 +230,8 @@
           Thanks for voting on this item
         </p>
       </div>
-
     </div><!-- .reporting -->
+
   </div>
 
   <div class="right" fxLayout fxLayoutAlign="end center">

--- a/src/app/market/listings/preview-listing/preview-listing.component.html
+++ b/src/app/market/listings/preview-listing/preview-listing.component.html
@@ -65,108 +65,105 @@
 
       </div><!-- .pricing -->
 
-      <mat-tab-group class="listing-tabs">
-
-        <mat-tab label="Details">
-          <div class="summary description">
-            <p>
-              {{ data?.listing?.shortDescription }}
-            </p>
-          </div>
-          <div class="detailed description">
-            <p>
-              {{ data?.listing?.longDescription }}
-            </p>
-          </div>
-          <table class="shipping-escrow">
-            <thead>
-              <tr>
-                <th></th>
-                <th>Worldwide</th>
-                <th [matTooltip]="countryListService?.getCountryByRegion(data?.listing?.country)?.name">
-                  Local in {{ data?.listing?.country }}
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th><strong>Shipping</strong></th>
-                <td>
-                  <span class="part price">
-                    <strong>{{ data?.listing?.internationalShippingPrice.getAmount() }}</strong> <small class="currency">PART</small>
-                  </span>
-                  <span class="fiat price">
-                    &asymp; 0.41 <small class="currency">EUR</small>
-                  </span>
-                </td>
-                <td>
-                  <span class="part price">
-                    <strong>{{ data?.listing?.domesticShippingPrice.getAmount() }}</strong> <small class="currency">PART</small>
-                  </span>
-                  <span class="fiat price">
-                    &asymp; 0.41 <small class="currency">EUR</small>
-                  </span>
-                </td>
-              </tr>
-              <tr>
-                <th>
-                  <strong>Escrow</strong><br>
-                  (refunded upon delivery)
-                </th>
-                <td>
-                  <span class="part price">
-                    <strong>{{ data?.listing?.escrowPriceInternational?.getAmount() }}</strong> <small class="currency">PART</small>
-                  </span>
-                  <span class="fiat price">
-                    &asymp; 0.41 <small class="currency">EUR</small>
-                  </span>
-                </td>
-                <td>
-                  <!-- FIXME: "escrow for local (not international)" needs to be implemented: -->
-                  <span class="part price">
-                    <strong>{{ data?.listing?.escrowPriceDomestic?.getAmount() }}</strong> <small class="currency">PART</small>
-                  </span>
-                  <span class="fiat price">
-                    &asymp; 0.41 <small class="currency">EUR</small>
-                  </span>
-                </td>
-              </tr>
-              <tr>
-                <th>
-                  <strong>Total needed for order</strong><br>
-                  (incl. refundable Escrow)
-                </th>
-                <!-- TODO: price + shipping + escrow -->
-                <td>
-                  <span class="part price">
-                    <strong>{{data?.listing?.totalAmountInternaltional?.getAmount()}}</strong> <small class="currency">PART</small>
-                  </span>
-                  <span class="fiat price">
-                    &asymp; 0.41 <small class="currency">EUR</small>
-                  </span>
-                </td>
-                <td>
-                  <span class="part price">
-                    <strong>{{data?.listing?.totalAmountDomestic?.getAmount()}}</strong> <small class="currency">PART</small>
-                  </span>
-                  <span class="fiat price">
-                    &asymp; 0.41 <small class="currency">EUR</small>
-                  </span>
-                </td>
-              </tr>
-            </tbody>
-          </table><!-- .shipping-escrow -->
-        </mat-tab><!-- details -->
-
-        <mat-tab label="Ratings">
-          ratings
-        </mat-tab><!-- ratings -->
-
-        <mat-tab label="Comments">
-          comments
-        </mat-tab><!-- comments -->
-
+      <mat-tab-group class="listing-tabs" (selectChange)="changeTab($event.index)">
+        <mat-tab label="Details"></mat-tab>
+        <mat-tab label="Comments"></mat-tab>
       </mat-tab-group><!-- .listing-tabs -->
+
+      <div class="tab-content details" *ngIf="tabLabels[selectedTab] == 'details'">
+        <div class="summary description">
+          <p>
+            {{ data?.listing?.shortDescription }}
+          </p>
+        </div>
+        <div class="detailed description">
+          <p>
+            {{ data?.listing?.longDescription }}
+          </p>
+        </div>
+        <table class="shipping-escrow">
+          <thead>
+            <tr>
+              <th></th>
+              <th>Worldwide</th>
+              <th [matTooltip]="countryListService?.getCountryByRegion(data?.listing?.country)?.name">
+                Local in {{ data?.listing?.country }}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th><strong>Shipping</strong></th>
+              <td>
+                <span class="part price">
+                  <strong>{{ data?.listing?.internationalShippingPrice.getAmount() }}</strong> <small class="currency">PART</small>
+                </span>
+                <span class="fiat price">
+                  &asymp; 0.41 <small class="currency">EUR</small>
+                </span>
+              </td>
+              <td>
+                <span class="part price">
+                  <strong>{{ data?.listing?.domesticShippingPrice.getAmount() }}</strong> <small class="currency">PART</small>
+                </span>
+                <span class="fiat price">
+                  &asymp; 0.41 <small class="currency">EUR</small>
+                </span>
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <strong>Escrow</strong><br>
+                (refunded upon delivery)
+              </th>
+              <td>
+                <span class="part price">
+                  <strong>{{ data?.listing?.escrowPriceInternational?.getAmount() }}</strong> <small class="currency">PART</small>
+                </span>
+                <span class="fiat price">
+                  &asymp; 0.41 <small class="currency">EUR</small>
+                </span>
+              </td>
+              <td>
+                <!-- FIXME: "escrow for local (not international)" needs to be implemented: -->
+                <span class="part price">
+                  <strong>{{ data?.listing?.escrowPriceDomestic?.getAmount() }}</strong> <small class="currency">PART</small>
+                </span>
+                <span class="fiat price">
+                  &asymp; 0.41 <small class="currency">EUR</small>
+                </span>
+              </td>
+            </tr>
+            <tr>
+              <th>
+                <strong>Total needed for order</strong><br>
+                (incl. refundable Escrow)
+              </th>
+              <!-- TODO: price + shipping + escrow -->
+              <td>
+                <span class="part price">
+                  <strong>{{data?.listing?.totalAmountInternaltional?.getAmount()}}</strong> <small class="currency">PART</small>
+                </span>
+                <span class="fiat price">
+                  &asymp; 0.41 <small class="currency">EUR</small>
+                </span>
+              </td>
+              <td>
+                <span class="part price">
+                  <strong>{{data?.listing?.totalAmountDomestic?.getAmount()}}</strong> <small class="currency">PART</small>
+                </span>
+                <span class="fiat price">
+                  &asymp; 0.41 <small class="currency">EUR</small>
+                </span>
+              </td>
+            </tr>
+          </tbody>
+        </table><!-- .shipping-escrow -->
+      </div><!-- .tab-content.details -->
+      
+      <div class="tab-content comments" *ngIf="tabLabels[selectedTab] == 'comments'">
+        Comments
+      </div>
 
     </div><!-- .product-info -->
   </div><!-- .product -->

--- a/src/app/market/listings/preview-listing/preview-listing.component.html
+++ b/src/app/market/listings/preview-listing/preview-listing.component.html
@@ -37,7 +37,6 @@
       <h1>{{ data?.listing?.title }}</h1>
 
       <div class="pricing">
-
         <div class="item price">
           <div class="title">Price</div>
           <div class="value part">
@@ -48,54 +47,53 @@
             <span class="fiat">~ {{price?.usd}} xx EUR</span>
           </div>
         </div>
-
-        <div class="summary description">
-          <p>
-            {{ data?.listing?.shortDescription }}
-          </p>
-        </div>
-
-        <table class="meta">
-          <tr>
-            <th class="title">
-              <mat-icon fontSet="partIcon" fontIcon="part-truck"></mat-icon>
-              Shipping
-            </th>
-            <td class="value">
-              {{ data?.listing?.domesticShippingPrice.getAmount() }} &ndash; {{ data?.listing?.internationalShippingPrice.getAmount() }} <small>PART</small>
-            </td>
-          </tr>
-          <tr>
-            <th class="title">
-              <mat-icon fontSet="partIcon" fontIcon="part-label"></mat-icon>
-              Category
-            </th>
-            <td class="value">
-              {{ data?.listing?.category.name }}
-            </td>
-          </tr>
-          <tr>
-            <th class="title">
-              <mat-icon fontSet="partIcon" fontIcon="part-globe"></mat-icon>
-              Sold from
-            </th>
-            <td class="value">
-              {{ countryListService?.getCountryByRegion(data?.listing?.country)?.name }}
-              ({{ data?.listing?.country }})
-            </td>
-          </tr>
-          <tr>
-            <th class="title">
-              <mat-icon fontSet="partIcon" fontIcon="part-date"></mat-icon>
-              Date added
-            </th>
-            <td class="value">
-              {{ data?.listing?.createdAt }}
-            </td>
-          </tr>
-        </table>
-
       </div><!-- .pricing -->
+
+      <div class="summary description">
+        <p>
+          {{ data?.listing?.shortDescription }}
+        </p>
+      </div>
+
+      <table class="meta">
+        <tr>
+          <th class="title">
+            <mat-icon fontSet="partIcon" fontIcon="part-truck"></mat-icon>
+            Shipping
+          </th>
+          <td class="value">
+            {{ data?.listing?.domesticShippingPrice.getAmount() }} &ndash; {{ data?.listing?.internationalShippingPrice.getAmount() }} <small>PART</small>
+          </td>
+        </tr>
+        <tr>
+          <th class="title">
+            <mat-icon fontSet="partIcon" fontIcon="part-label"></mat-icon>
+            Category
+          </th>
+          <td class="value">
+            {{ data?.listing?.category.name }}
+          </td>
+        </tr>
+        <tr>
+          <th class="title">
+            <mat-icon fontSet="partIcon" fontIcon="part-globe"></mat-icon>
+            Sold from
+          </th>
+          <td class="value">
+            {{ countryListService?.getCountryByRegion(data?.listing?.country)?.name }}
+            ({{ data?.listing?.country }})
+          </td>
+        </tr>
+        <tr>
+          <th class="title">
+            <mat-icon fontSet="partIcon" fontIcon="part-date"></mat-icon>
+            Date added
+          </th>
+          <td class="value">
+            {{ data?.listing?.createdAt }}
+          </td>
+        </tr>
+      </table>
 
     </div><!-- .product-info -->
   </div><!-- .product-summary -->

--- a/src/app/market/listings/preview-listing/preview-listing.component.scss
+++ b/src/app/market/listings/preview-listing/preview-listing.component.scss
@@ -57,6 +57,8 @@ button.small .mat-icon {
 .dialog-content {
   margin: 0 -24px !important;
   width: 950px;
+  height: 65vh;
+  max-height: none;
 }
 
 [mat-dialog-title] {
@@ -98,14 +100,8 @@ button.small .mat-icon {
       }
     }
     .listing-tabs {
-      .mat-tab-header {
-        background: rgba($color-white, 0.92);
-        position: sticky;
-        top: 70px;
-        z-index: 20;
-      }
       .mat-tab-label {
-        width: (100% / 3);
+        width: (100% / 2);
       }
     }
   }
@@ -115,6 +111,22 @@ button.small .mat-icon {
   color: $text-muted;
   line-height: 1.7;
   margin-right: -24px;
+
+  // Tabs
+  .listing-tabs { // tabs in Listing desc (details / comments / ratings etc.)
+    position: sticky;
+    top: 70px;
+    z-index: 20;
+    background: rgba($color-white, 0.92);
+  }
+
+  // Tabs' content
+  .tab-content {
+    padding: 16px 40px;
+    &.details {
+      padding: 0;
+    }
+  }
 
   // Price info
   .pricing {

--- a/src/app/market/listings/preview-listing/preview-listing.component.scss
+++ b/src/app/market/listings/preview-listing/preview-listing.component.scss
@@ -54,37 +54,6 @@ button.small .mat-icon {
 
 // ------ LAYOUT ------ //
 
-.dialog-content {
-  margin: 0 -24px !important;
-  width: 950px;
-  height: 65vh;
-  max-height: none;
-}
-
-/*
-[mat-dialog-title] {
-  color: $text;
-  .category {
-    font-size: 12px;
-    font-weight: normal;
-    color: $text-muted;
-    margin-left: 10px;
-  }
-}
-*/
-
-.product-gallery {
-  .gallery-carousel {
-    img { // single product image
-      width: 100%;
-      height: auto;
-    }
-  }
-  gallery { // multiple product images in gallery
-    background: none;
-  }
-}
-
 :host {
   ::ng-deep {
     image-item {
@@ -107,16 +76,40 @@ button.small .mat-icon {
   }
 }
 
+.dialog-content {
+  margin: 0 -24px !important;
+  width: 950px;
+  height: 65vh;
+  max-height: none;
+}
+
+.product-gallery {
+  margin-right: 35px;
+  .gallery-carousel {
+    img { // single product image
+      width: 100%;
+      height: auto;
+    }
+  }
+  gallery { // multiple product images in gallery
+    background: none;
+  }
+}
+
+.product-summary { // container for upper part (gallery, name, meta)
+  margin-bottom: 24px;
+}
+
 .product-info {
-  color: $text-muted;
   line-height: 1.7;
   margin-right: -24px;
 
+  h1 { // product name
+    font-size: 1.7em;
+  }
+
   // Price info
   .pricing {
-    background: $color-white;
-    border-bottom: 1px solid $bg-shadow;
-    width: 100%;
     .item {
       .title {
         @extend %subtitle;
@@ -126,13 +119,14 @@ button.small .mat-icon {
       }
       .value {
         &.part {
-          font-size: 16px;
+          font-size: 2em;
           font-weight: 500;
           color: $text;
           line-height: 1.2;
+          margin: 0;
         }
         .currency {
-          font-size: 80%;
+          font-size: 60%;
           font-weight: 400;
         }
         .mat-icon {
@@ -151,19 +145,20 @@ button.small .mat-icon {
   margin: 18px 0;
   word-wrap: break-word;
   &.summary {
-    font-weight: 600;
+    font-weight: 500;
     color: $text;
-    font-size: 14px;
-    margin: 0;
-    padding: 2px 40px;
+    font-size: 110%;
+    margin: 24px 0 24px -30px;
+    padding: 2px 40px 2px 30px;
     background: $bg;
   }
   &.detailed {
+    @extend %enable-select;
     margin: 24px 8px;
     p {
       white-space: pre-line;
-      column-gap: 30px;
       column-count: 2;
+      column-gap: 30px;
     }
   }
 }

--- a/src/app/market/listings/preview-listing/preview-listing.component.scss
+++ b/src/app/market/listings/preview-listing/preview-listing.component.scss
@@ -112,10 +112,8 @@ button.small .mat-icon {
   .pricing {
     .item {
       .title {
-        @extend %subtitle;
-        margin: 0;
-        padding-bottom: 4px;
-        border-bottom: 0;
+        @extend %lighter;
+        text-transform: uppercase;
       }
       .value {
         &.part {
@@ -157,6 +155,7 @@ button.small .mat-icon {
     margin: 24px 8px;
     p {
       white-space: pre-line;
+      line-height: 1.55;
       column-count: 2;
       column-gap: 30px;
     }
@@ -164,15 +163,6 @@ button.small .mat-icon {
 }
 
 .product-details {
-  /*
-  // Tabs
-  .listing-tabs { // tabs in Listing desc (details / comments / ratings etc.)
-    position: sticky;
-    top: 70px;
-    z-index: 20;
-    background: rgba($color-white, 0.92);
-  }
-  */
 
   // Tabs' content
   .tab-content {
@@ -230,21 +220,15 @@ button.small .mat-icon {
 }
 
 mat-dialog-actions {
-  .date {
-    color: $text-muted;
-    display: inline-block;
-    margin-left: 8px;
-    strong {
-      font-weight: 500;
-    }
-  }
-
   // Listing governance
   .reporting {
-    color: $text-muted;
     display: inline-block;
     .title {
       margin-right: 6px;
+      @extend %lighter;
+    }
+    .voted {
+      @extend %lighter;
     }
     .voted-icon {
       margin-right: 4px;
@@ -260,7 +244,6 @@ mat-dialog-actions {
       }
     }
   }
-
   app-favorite { // add/remove from favs icon
     margin-right: 6px;
   }

--- a/src/app/market/listings/preview-listing/preview-listing.component.scss
+++ b/src/app/market/listings/preview-listing/preview-listing.component.scss
@@ -97,6 +97,17 @@ button.small .mat-icon {
         filter: invert(10%);
       }
     }
+    .listing-tabs {
+      .mat-tab-header {
+        background: rgba($color-white, 0.92);
+        position: sticky;
+        top: 70px;
+        z-index: 20;
+      }
+      .mat-tab-label {
+        width: (100% / 3);
+      }
+    }
   }
 }
 

--- a/src/app/market/listings/preview-listing/preview-listing.component.scss
+++ b/src/app/market/listings/preview-listing/preview-listing.component.scss
@@ -119,7 +119,6 @@ button.small .mat-icon {
         &.part {
           font-size: 2em;
           font-weight: 500;
-          color: $text;
           line-height: 1.2;
           margin: 0;
         }
@@ -158,26 +157,21 @@ button.small .mat-icon {
 }
 
 // Text description
-.description {
-  margin: 18px 0;
+p.description {
   word-wrap: break-word;
   &.summary {
     font-weight: 500;
     color: $text;
     font-size: 110%;
     margin: 24px 0 24px -30px;
-    padding: 2px 40px 2px 30px;
+    padding: 18px 40px 18px 30px;
     background: $bg;
   }
   &.detailed {
     @extend %enable-select;
-    margin: 24px 8px;
-    p {
-      white-space: pre-line;
-      line-height: 1.55;
-      column-count: 2;
-      column-gap: 30px;
-    }
+    white-space: pre-line;
+    column-count: 2;
+    column-gap: 30px;
   }
 }
 
@@ -185,50 +179,69 @@ button.small .mat-icon {
 
   // Tabs' content
   .tab-content {
-    padding: 16px 40px;
-    &.details {
-      padding: 0;
+    min-height: 230px; // bigger by default (prevents tabs from jumping with little content)
+    margin: 24px 8px;
+    line-height: 1.55;
+    &.shipping {
+      margin: 24px 0; // make shipping table full-width
     }
   }
 
   // Shipping & escrow
   table.shipping-escrow {
     width: 100%;
-    padding-left: 28px;
+    font-size: 110%;
     thead {
       th {
-        font-size: 11px;
-        font-weight: 400;
-        text-transform: uppercase;
-        padding: 6px 12px;
+        @extend %lighter;
+        font-weight: 500;
+        padding: 0 12px 12px;
+        vertical-align: bottom;
       }
     }
     tbody {
       tr {
         th {
-          font-weight: 400;
+          font-weight: 700;
+          small {
+            @extend %lighter;
+            font-size: 90%;
+            font-weight: 400;
+            display: block;
+          }
         }
         th,
         td {
           @extend %tfx;
           border-top: 1px solid $bg-shadow;
-          padding: 6px 12px;
+          padding: 12px;
+          max-width: 150px; // space out cells ~evenly
         }
-        &:hover {
+        &:hover:not(.help-text) {
           th,
           td {
-            background: mix($bg, $color-white);
+            background: rgba($color, 0.03);
+          }
+        }
+        &.help-text {
+          td {
+            vertical-align: top;
+            small {
+              @extend %lighter;
+            }
           }
         }
       }
     }
     strong {
-      color: $text;
       font-weight: 500;
     }
     .price {
       &.part {
         display: block;
+        strong {
+          font-size: 110%;
+        }
       }
     }
     small.currency {

--- a/src/app/market/listings/preview-listing/preview-listing.component.scss
+++ b/src/app/market/listings/preview-listing/preview-listing.component.scss
@@ -136,6 +136,25 @@ button.small .mat-icon {
       }
     }
   }
+
+  // meta table (shipping, category, sold from & date added)
+  table.meta {
+    th.title {
+      @extend %lighter;
+      font-weight: 500;
+      padding: 4px 24px 0 0;
+    }
+    td {
+      padding: 4px 0 0;
+    }
+    .mat-icon {
+      @extend %lighter;
+      font-size: 14px;
+      margin-right: 6px;
+      position: relative;
+      top: 2px;
+    }
+  }
 }
 
 // Text description

--- a/src/app/market/listings/preview-listing/preview-listing.component.scss
+++ b/src/app/market/listings/preview-listing/preview-listing.component.scss
@@ -61,6 +61,7 @@ button.small .mat-icon {
   max-height: none;
 }
 
+/*
 [mat-dialog-title] {
   color: $text;
   .category {
@@ -70,11 +71,10 @@ button.small .mat-icon {
     margin-left: 10px;
   }
 }
+*/
 
 .product-gallery {
   .gallery-carousel {
-    position: sticky;
-    top: 0;
     img { // single product image
       width: 100%;
       height: auto;
@@ -112,31 +112,11 @@ button.small .mat-icon {
   line-height: 1.7;
   margin-right: -24px;
 
-  // Tabs
-  .listing-tabs { // tabs in Listing desc (details / comments / ratings etc.)
-    position: sticky;
-    top: 70px;
-    z-index: 20;
-    background: rgba($color-white, 0.92);
-  }
-
-  // Tabs' content
-  .tab-content {
-    padding: 16px 40px;
-    &.details {
-      padding: 0;
-    }
-  }
-
   // Price info
   .pricing {
-    position: sticky;
-    top: 0;
-    z-index: 10;
     background: $color-white;
     border-bottom: 1px solid $bg-shadow;
     width: 100%;
-    padding: 0 40px 20px;
     .item {
       .title {
         @extend %subtitle;
@@ -164,26 +144,46 @@ button.small .mat-icon {
       }
     }
   }
+}
 
-  // Text description
-  .description {
-    margin: 18px 0;
-    word-wrap: break-word;
-    width: 438px;
-    &.summary {
-      font-weight: 600;
-      color: $text;
-      font-size: 14px;
-      margin: 0;
-      padding: 2px 40px;
-      background: $bg;
+// Text description
+.description {
+  margin: 18px 0;
+  word-wrap: break-word;
+  &.summary {
+    font-weight: 600;
+    color: $text;
+    font-size: 14px;
+    margin: 0;
+    padding: 2px 40px;
+    background: $bg;
+  }
+  &.detailed {
+    margin: 24px 8px;
+    p {
+      white-space: pre-line;
+      column-gap: 30px;
+      column-count: 2;
     }
-    &.detailed {
-      margin: 24px 40px 40px;
-      p {
-        white-space: pre-line;
-        margin-top: -20px;
-      }
+  }
+}
+
+.product-details {
+  /*
+  // Tabs
+  .listing-tabs { // tabs in Listing desc (details / comments / ratings etc.)
+    position: sticky;
+    top: 70px;
+    z-index: 20;
+    background: rgba($color-white, 0.92);
+  }
+  */
+
+  // Tabs' content
+  .tab-content {
+    padding: 16px 40px;
+    &.details {
+      padding: 0;
     }
   }
 

--- a/src/app/market/listings/preview-listing/preview-listing.component.ts
+++ b/src/app/market/listings/preview-listing/preview-listing.component.ts
@@ -30,7 +30,7 @@ export class PreviewListingComponent implements OnInit, OnDestroy {
   images: ImageItem[] = [];
 
   public selectedTab: number = 0;
-  public tabLabels: Array<string> = ['details', 'comments'];
+  public tabLabels: Array<string> = ['details', 'shipping', 'comments'];
 
   constructor(
     private dialogRef: MatDialogRef<PreviewListingComponent>,

--- a/src/app/market/listings/preview-listing/preview-listing.component.ts
+++ b/src/app/market/listings/preview-listing/preview-listing.component.ts
@@ -29,6 +29,9 @@ export class PreviewListingComponent implements OnInit, OnDestroy {
   private currencyprice: number = 0;
   images: ImageItem[] = [];
 
+  public selectedTab: number = 0;
+  public tabLabels: Array<string> = ['details', 'comments'];
+
   constructor(
     private dialogRef: MatDialogRef<PreviewListingComponent>,
     private marketState: MarketStateService,
@@ -105,4 +108,9 @@ export class PreviewListingComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.destroyed = true;
   }
+
+  changeTab(index: number): void {
+    this.selectedTab = index;
+  }
+
 }


### PR DESCRIPTION
Title says it all. Shuffled stuff around a bit. 1000-word preview below:

![listing-redesign](https://user-images.githubusercontent.com/1965795/49819675-57742d80-fd76-11e8-949f-a56cc087466e.gif)

- implemented tabs for additional info (future-proofing for Ratings, Reviews and more)
- image gallery resized a bit, to fit most common photo ratios
- no more sticky stuff = place for more info (check this in full HD+)
- Shipping & Escrow table swapped (from vertical to horizontal, makes more sense + future-proof for more than 2 shipping options/carriers etc.) & redesigned
- a lot of infos found a new home, redesigned

> @zaSmilingIdiot can I have this merged ASAP so I can continue on the Comments section? :)