### PR TITLE
Fixes creation of cloned listings

### DIFF
--- a/src/app/core/market/api/template/image/image.model.ts
+++ b/src/app/core/market/api/template/image/image.model.ts
@@ -28,6 +28,17 @@ export class Image {
     return (image && image.dataId) || './assets/images/placeholder_1-1.jpg'
   }
 
+  get originalEncoding(): string {
+    const image = this.image.ItemImageDatas.find(o => o.imageVersion === 'ORIGINAL');
+    let data = '';
+    if (image) {
+      if (image.originalMime && (image.encoding === 'BASE64') && image.ItemImageDataContent && image.ItemImageDataContent.data) {
+        data += `data:${image.originalMime};${image.encoding.toLowerCase()},${image.ItemImageDataContent.data}`
+      }
+    }
+    return data;
+  }
+
 }
 
 export class DefaultImage extends Image {

--- a/src/app/market/sell/add-item/add-item.component.ts
+++ b/src/app/market/sell/add-item/add-item.component.ts
@@ -292,7 +292,6 @@ export class AddItemComponent implements OnInit, OnDestroy {
 
   private async update() {
     const item = this.itemFormGroup.value;
-    this.isInProcess = true;
     // update information
     if (this.isTemplateInfoUpdated(item)) {
       await this.information.update(
@@ -389,6 +388,8 @@ export class AddItemComponent implements OnInit, OnDestroy {
       this.snackbar.open('You can not update templates whilst they are published!');
       return;
     }
+
+    this.isInProcess = true;
 
     this.upsert()
     .then(t => {

--- a/src/app/market/sell/add-item/add-item.component.ts
+++ b/src/app/market/sell/add-item/add-item.component.ts
@@ -97,11 +97,7 @@ export class AddItemComponent implements OnInit, OnDestroy {
       const clone: boolean = params['clone'];
       if (id) {
         this.templateId = +id;
-        this.preload();
-      }
-      if (clone) {
-        this.log.d('Cloning listing!');
-        this.templateId = undefined;
+        this.preload(clone);
       }
     });
 
@@ -189,7 +185,7 @@ export class AddItemComponent implements OnInit, OnDestroy {
     this.destroyed = true;
   }
 
-  preload() {
+  preload(isCloned: boolean) {
     this.log.d(`preloading for id=${this.templateId}`);
     this.template.get(this.templateId).subscribe((template: Template) => {
       this.log.d(`preloaded id=${this.templateId}!`);
@@ -226,10 +222,13 @@ export class AddItemComponent implements OnInit, OnDestroy {
       t.internationalShippingPrice = template.internationalShippingPrice.getAmount();
       this.itemFormGroup.patchValue(t);
 
-      this.images = template.imageCollection.images;
-
-      this.preloadedTemplate = template;
-      // this.itemFormGroup.get('category').setValue(t.category, {emitEvent: true});
+      if (isCloned) {
+        this.picturesToUpload = template.imageCollection.images.map(img => img.originalEncoding).filter(img => img.length);
+        this.templateId = undefined;
+      } else {
+        this.images = template.imageCollection.images;
+        this.preloadedTemplate = template;
+      }
     });
   }
 


### PR DESCRIPTION
Cloned templates were referring to the original template, and were thus unable to be saved (or subsequently published) if the original template had a published listing associated with it. Which meant cloning a template would only be possible for an unpublished listing, which is somewhat pointless. 

The clone button now properly sets up a new template using the details of the cloned template, allowing for a new template and subsequent listing item to be created.

Also includes a fix for displaying the loading overlay when a new template is created (previously the loading overlay was only displayed on publishing of the template or when a saved template was being updated, but not on the saving of a new template).

References back to: https://particl.atlassian.net/browse/PBD-159