### PR TITLE
Ensures addressindex flag is included on daemon startup

### DIFF
--- a/modules/daemon/daemon.js
+++ b/modules/daemon/daemon.js
@@ -10,6 +10,7 @@ const rpc = require('../rpc/rpc');
 const cookie = require('../rpc/cookie');
 const daemonManager = require('../daemon/daemonManager');
 const multiwallet = require('../multiwallet');
+const daemonConfig = require('./daemonConfig');
 
 let daemon = undefined;
 let chosenWallets = [];
@@ -43,7 +44,6 @@ exports.restart = function (alreadyStopping) {
     daemon.once('close', code => {
       // clear authentication
       clearCookie();
-      
       // restart
       this.start(chosenWallets);
     });
@@ -61,6 +61,13 @@ exports.restart = function (alreadyStopping) {
 }
 
 exports.start = function (wallets) {
+  let doReindex = false;
+  const daemonSettings = daemonConfig.getSettings();
+  if (!(daemonSettings.global && daemonSettings.global.addressindex === 1)) {
+    daemonConfig.saveSettings({addressindex: true});
+    doReindex = true;
+  }
+
   return (new Promise((resolve, reject) => {
 
     chosenWallets = wallets;
@@ -76,10 +83,17 @@ exports.start = function (wallets) {
         ? options.customdaemon
         : daemonManager.getPath();
 
-      wallets = wallets.map(wallet => `-wallet=${wallet}`);
-      log.info(`starting daemon ${daemonPath} ${process.argv} ${wallets}`);
 
-      const child = spawn(daemonPath, [...process.argv, "-rpccorsdomain=http://localhost:4200", ...wallets])
+      const addedArgs = [];
+
+      if (doReindex) {
+        addedArgs.push('-reindex-chainstate');
+      }
+      wallets = wallets.map(wallet => `-wallet=${wallet}`);
+      const deamonArgs = [...process.argv, "-rpccorsdomain=http://localhost:4200", ...wallets, ...addedArgs];
+      log.info(`starting daemon: ${deamonArgs}`);
+
+      const child = spawn(daemonPath, deamonArgs)
         .on('close', code => {
           log.info('daemon exited - setting to undefined.');
           daemon = undefined;

--- a/modules/daemon/daemon.js
+++ b/modules/daemon/daemon.js
@@ -61,11 +61,15 @@ exports.restart = function (alreadyStopping) {
 }
 
 exports.start = function (wallets) {
+  let options = _options.get();
   let doReindex = false;
-  const daemonSettings = daemonConfig.getSettings();
-  if (!(daemonSettings.global && daemonSettings.global.addressindex === 1)) {
-    daemonConfig.saveSettings({addressindex: true});
-    doReindex = true;
+
+  if (+options.addressindex !== 1) {
+    const daemonSettings = daemonConfig.getSettings();
+    if (!(daemonSettings.global && daemonSettings.global.addressindex === 1)) {
+      daemonConfig.saveSettings({addressindex: true});
+      doReindex = true;
+    }
   }
 
   return (new Promise((resolve, reject) => {
@@ -78,7 +82,6 @@ exports.start = function (wallets) {
 
     }).catch(() => {
 
-      let options = _options.get();
       const daemonPath = options.customdaemon
         ? options.customdaemon
         : daemonManager.getPath();

--- a/modules/daemon/daemonConfig.js
+++ b/modules/daemon/daemonConfig.js
@@ -1,0 +1,198 @@
+const fs          = require('fs');
+const path        = require('path');
+const log         = require('electron-log');
+const iniParser   = require('@jedmao/ini-parser').default;
+const cookie      = require('../rpc/cookie');
+const _options    = require('../options');
+
+const conFilePath = path.join( cookie.getParticlPath(_options.get()), 'particl.conf');
+const SAFE_KEYS = ['addressindex'];
+
+
+const formatSettingsOutput = function(rawConfig) {
+  let formattedConfig = {};
+
+    let sections = [];
+    if (Object.prototype.toString.call(rawConfig) === '[object Object]' && Object.prototype.toString.call(rawConfig.items) === '[object Array]') {
+      sections = rawConfig.items;
+    }
+
+    let sectionKey;
+
+  try {
+    for (let ii=0; ii < sections.length; ii++) {
+      const section = sections[ii];
+
+      if ( (('name' in section) && String(section.name).length) || !sectionKey) {
+        sectionKey = section.name || 'global';
+
+        sectionKey = String(sectionKey).trim();
+        if (!(sectionKey in formattedConfig)) {
+          formattedConfig[sectionKey] = {};
+        }
+      }
+
+      const hasNodes = Object.prototype.toString.call(section.nodes) === '[object Array]' && section.nodes.length > 0;
+
+      if (hasNodes) {
+        for (let jj = 0; jj < section.nodes.length; jj++) {
+          const node = section.nodes[jj];
+          if (Object.prototype.toString.call(node) === '[object Object]' && ('key' in node) && ('value' in node)) {
+            formattedConfig[sectionKey][String(node.key)] = node.value;
+          }
+        }
+      }
+    }
+  } catch (err) {
+    log.error(`Failed formatting daemonConfig: `, err.stack);
+    formattedConfig = {};
+  }
+
+  return formattedConfig;
+}
+
+const readConfigFile = function () {
+  log.debug('Attempting to read particld config from: ', conFilePath);
+  if (fs.existsSync(conFilePath)) {
+    try {
+      const p = new iniParser();
+      const result = p.parse(fs.readFileSync(conFilePath, 'utf-8'));
+      return JSON.parse(JSON.stringify(result));
+    } catch (err) {
+      log.error(`particld config file parsing failed from ${conFilePath}`);
+      log.error(`parsing error: ${err.message}`);
+    }
+  }
+  return {};
+}
+
+
+const getSettings = function(rawOutput = false) {
+  const parsedConfig = readConfigFile();
+
+  if (rawOutput === true) {
+    return parsedConfig;
+  }
+  return formatSettingsOutput(parsedConfig);
+}
+
+
+const saveSettings = function(networkOpt) {
+  // TODO: Only accepts global config changes for now (no section config changes at the moment) - this should be changed.
+
+  let items = [];
+  if (Object.prototype.toString.call(networkOpt) !== '[object Object]' ) {
+    return;
+  }
+  let keys = Object.keys(networkOpt).filter(
+    (key) => networkOpt.hasOwnProperty(key) && SAFE_KEYS.includes(key) && ['string', 'number', 'boolean'].includes(typeof networkOpt[key])
+  );
+
+  // make certain that the latest config data has been obtained.
+  const latest = getSettings(true);
+  if (Object.prototype.toString.call(latest.items) === '[object Array]' ) {
+    items = latest.items;
+  }
+
+  // TODO: clean this crappy code up - which means: reduce the double memory footprint of
+  //  having 2 copies of the file in memory (one in JSON and the other as the output)
+  //  This can be done better with streams.
+
+  let output = '';
+  let isModified = false;
+  let isGlobalConfig = true;
+
+  for (let ii = 0; ii < items.length; ii++) {
+    const section = items[ii];
+    const hasNodes = Object.prototype.toString.call(section.nodes) === '[object Array]';
+
+    if ('name' in section) {
+      // section delimiting (could be global config item or blank line as well)
+      let name = section.name;
+      if (section.name.length && hasNodes && section.nodes.length) {
+        // Start of a new section
+
+        if (isGlobalConfig) {
+          isGlobalConfig = false;
+
+          // New keys (settings) that need to be saved
+          if (keys.length) {
+            for (const key of keys) {
+              output += `${key}=${typeof networkOpt[key] === 'boolean' ? +networkOpt[key] : networkOpt[key]}${section.newline}`;
+            }
+            output += `${section.newline}`;
+            isModified = true;
+            keys = [];
+          }
+        }
+
+        name = `[${section.name}]`;
+      }
+      output += `${name}${section.newline}`;
+    }
+
+    if (section.indicator) {
+      // section comments
+      output += `${section.indicator}${section.text || ''}${section.newline}`;
+    }
+
+    if (hasNodes) {
+      for (let jj = 0; jj < section.nodes.length; jj++) {
+        const node = section.nodes[jj];
+
+        if ( node.hasOwnProperty('key') ) {
+          // key-value pairs
+          let value = node.hasOwnProperty('value') ? node.value : '';
+          value = typeof value === 'boolean' ? +value : value;
+
+          // Update existing global keys (settings)
+          if (isGlobalConfig && keys.length) {
+            const keyIdx = keys.findIndex((elem) => elem === node.key);
+            if (keyIdx > -1) {
+              const newVal = typeof networkOpt[node.key] === 'boolean' ? +networkOpt[node.key] : networkOpt[node.key];
+              if (value !== newVal) {
+                value = newVal;
+                isModified = true;
+              }
+              keys.splice(keyIdx, 1);
+            }
+          }
+          output += `${node.key}${node.delimiter}${value}${section.newline}`;
+        } else if (node.indicator) {
+          // comments
+          output += `${node.indicator}${node.text || ''}${section.newline}`;
+        }
+      }
+    }
+  }
+
+  if (keys.length) {
+    // Should only be here if conFilePath returned no data (config file exists?)
+
+    for (const key of keys) {
+      output += `${key}=${typeof networkOpt[key] === 'boolean' ? +networkOpt[key] : networkOpt[key]}\n`;
+    }
+
+    isModified = true;
+  }
+
+  if (isModified) {
+    const tmpConfPath = conFilePath + '.tmp';
+    fs.writeFile(tmpConfPath, output, (err) => {
+      if (err) {
+        log.error(`Failed writing changes to ${tmpConfPath}`, err.stack);
+      } else {
+        fs.rename(tmpConfPath, conFilePath, (error) => {
+          if (error) {
+            log.error(`Failed updating ${conFilePath}`, err.stack);
+          } else {
+            log.info('Successfully set particld configuration at', conFilePath);
+          }
+        });
+      }
+    });
+  }
+}
+
+exports.getSettings = getSettings;
+exports.saveSettings = saveSettings;

--- a/modules/daemon/update.js
+++ b/modules/daemon/update.js
@@ -9,7 +9,7 @@ const UPDATE_CHANNEL = 'daemon';
 let mainReference = null;
 
 exports.init = function (mainWindow) {
-    /* 
+    /*
         Store a reference of the main window (electron),
         which we need for rx-ipc-electron (need to get webContents).
     */

--- a/modules/init.js
+++ b/modules/init.js
@@ -28,13 +28,7 @@ exports.start = function (mainWindow) {
   // zmq.test(); // loop, will send tests
 
   /* Initialize daemonWarner */
-  // warns GUI that daemon is downloading
   daemonWarner.init(mainWindow);
-  daemonManager.on('status', (status, msg) => {
-    if (status === "download") {
-      daemonWarner.send(msg);
-    }
-  });
 
   exports.startDaemonManager();
 }
@@ -53,6 +47,11 @@ exports.startDaemonManager = function() {
   Only happens _after_ daemonManager.init()
 */
 daemonManager.on('status', (status, msg) => {
+
+  // warns GUI that daemon is downloading
+  if (status === "download") {
+    daemonWarner.send(msg);
+  }
 
   // Done -> means we have a binary!
   if (status === 'done') {

--- a/modules/rpc/cookie.js
+++ b/modules/rpc/cookie.js
@@ -97,7 +97,7 @@ function getAuth(options) {
   }
 
   let auth;
-  var dataDir = options.datadir ? options.datadir : findCookiePath();
+  var dataDir = getParticlPath(options);
   const COOKIE_FILE = dataDir
                     + (options.testnet ? '/testnet' : '')
                     + '/.cookie';
@@ -112,4 +112,9 @@ function getAuth(options) {
   return (auth)
 }
 
+function getParticlPath(options) {
+  return options.datadir ? options.datadir : findCookiePath();
+}
+
 exports.getAuth = getAuth;
+exports.getParticlPath = getParticlPath;

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     ]
   },
   "dependencies": {
+    "@jedmao/ini-parser": "^0.2.1",
     "@ngx-gallery/core": "2.2.0",
     "@ngx-gallery/gallerize": "2.2.0",
     "@ngx-gallery/lightbox": "2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -262,6 +262,11 @@
     is-absolute "^1.0.0"
     is-negated-glob "^1.0.0"
 
+"@jedmao/ini-parser@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@jedmao/ini-parser/-/ini-parser-0.2.1.tgz#4b4ec9d2374a3edc5adc4956e85d476fe2f81ba2"
+  integrity sha512-jn6wJLQFye37xk6c0hDD7tiyffdqQGH5Ah9faFJjtKrTWXf2jlBLqZDL6uGIPD8HJ69ulBll1bILFg6O/bkcVA==
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"


### PR DESCRIPTION
Checks if the addressindex flag is added as a cli flag. If not, read the particl.conf: if its not set or set to disabled, then write change to the particl.conf file and ensure that -reindex-chainstate flag is used when starting the daemon up.