### PR TITLE
GFX/Layout tweaks (No. XII)

### DIFF
--- a/src/app/market/_product-card.scss
+++ b/src/app/market/_product-card.scss
@@ -1,0 +1,56 @@
+@import './src/assets/_config'; // import shared colors etc.
+
+/*
+    PRODUCT CARD
+    Listing thumbnail for Market & Favourites
+*/
+
+$card-margin: 25px;
+
+// item
+
+mat-card.listing {
+  margin: 0 $card-margin $card-margin 0;
+  padding: 24px 16px 12px;
+
+  // default: 4 columns
+  flex: calc((100% / 4) - 51px);
+  max-width: calc((100% / 4) - 51px);
+  &:nth-of-type(4n) {
+    margin-right: 0;
+    @include break-from(1650px) {
+      margin-right: $card-margin;
+    }
+  }
+
+  // larger: 6 columns
+  @include break-from(1650px) {
+    flex: calc((100% / 6) - 53px);
+    max-width: calc((100% / 6) - 53px);
+    &:nth-of-type(6n) {
+      margin-right: 0;
+    }
+  }
+
+  // largest: 8 columns
+  @include break-from(2300px) {
+    flex: calc((100% / 8) - 55px);
+    max-width: calc((100% / 8) - 55px);
+    &:nth-of-type(6n) {
+      margin-right: $card-margin;
+    }
+    &:nth-of-type(8n) {
+      margin-right: 0;
+    }
+  }
+
+}
+
+
+// container
+
+.grid-container {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+}

--- a/src/app/market/buy/buy.component.html
+++ b/src/app/market/buy/buy.component.html
@@ -83,7 +83,7 @@
   <div *ngIf="favorites !== undefined && favorites.length != 0" class="grid-container">
     <ng-container *ngFor="let favorite of favorites">
 
-      <mat-card class="listing"><!-- fxFlex="0 0 calc(100% / 4 - 30px)" -->
+      <mat-card class="listing">
         <app-listing-item [listing]="favorite"></app-listing-item>
       </mat-card>
 

--- a/src/app/market/buy/buy.component.html
+++ b/src/app/market/buy/buy.component.html
@@ -39,13 +39,13 @@
 <div class="container-block with-tab-bar" *ngIf="tabLabels[selectedTab] == 'orders'">
 
   <div class="page-intro">
-    <h1>Buying orders</h1>
+    <h1>Buy Orders</h1>
     <div class="content">
       <p>
-        This is where you manage your Orders, that you're buying on the Market from other Sellers.
+        This is where you manage the orders you're in the process of buying from other vendors on the marketplace.
       </p>
       <p class="widget-help">
-        Each Order advancement needs to be confirmed on this page, e.g. paying for items &amp; marking Orders as delivered.
+        Each step of the purchasing process needs to be confirmed in this page (i.e. marking an order as "Delivered").
       </p>
     </div>
   </div><!-- .page-intro -->
@@ -60,13 +60,13 @@
      *ngIf="tabLabels[selectedTab] == 'favourites'">
 
   <div class="page-intro">
-    <h1>Your favourites</h1>
+    <h1>Your Favourites</h1>
     <div class="content">
       <p>
-        Save your favourite Listings for easy access later.
+        Save your favourite listings to easily access them later on.
       </p>
       <p class="widget-help">
-        Note that all Listings on Market have a limited lifetime (they expire in time), so be sure to check back often as they might not be available on Market anymore.
+        Note that marketplace listings have a limited lifetime (they expire after some time), so make sure to check back here often as they might not be available on the marketplace anymore.
       </p>
     </div>
   </div><!-- .page-intro -->

--- a/src/app/market/buy/buy.component.html
+++ b/src/app/market/buy/buy.component.html
@@ -55,11 +55,13 @@
     </p>
   </div>
 
-  <div *ngIf="favorites !== undefined && favorites.length != 0" fxLayout="row wrap" fxLayoutAlign="start start">
+  <div *ngIf="favorites !== undefined && favorites.length != 0" class="content">
     <ng-container *ngFor="let favorite of favorites">
-      <mat-card class="listing" fxFlex="0 0 calc(100% / 4 - 30px)">
+
+      <mat-card class="listing"><!-- fxFlex="0 0 calc(100% / 4 - 30px)" -->
         <app-listing-item [listing]="favorite"></app-listing-item>
       </mat-card>
+
     </ng-container>
   </div>
 

--- a/src/app/market/buy/buy.component.html
+++ b/src/app/market/buy/buy.component.html
@@ -37,6 +37,19 @@
 <!-- =========== ORDERS =========== -->
 
 <div class="container-block with-tab-bar" *ngIf="tabLabels[selectedTab] == 'orders'">
+
+  <div class="page-intro">
+    <h1>Buying orders</h1>
+    <div class="content">
+      <p>
+        This is where you manage your Orders, that you're buying on the Market from other Sellers.
+      </p>
+      <p class="widget-help">
+        Each Order advancement needs to be confirmed on this page, e.g. paying for items &amp; marking Orders as delivered.
+      </p>
+    </div>
+  </div><!-- .page-intro -->
+  
   <app-orders type="buy"></app-orders>
 </div><!-- "Orders" tab -->
 
@@ -45,6 +58,18 @@
 
 <div class="favourites container-block with-tab-bar"
      *ngIf="tabLabels[selectedTab] == 'favourites'">
+
+  <div class="page-intro">
+    <h1>Your favourites</h1>
+    <div class="content">
+      <p>
+        Save your favourite Listings for easy access later.
+      </p>
+      <p class="widget-help">
+        Note that all Listings on Market have a limited lifetime (they expire in time), so be sure to check back often as they might not be available on Market anymore.
+      </p>
+    </div>
+  </div><!-- .page-intro -->
 
   <div class="no-results" *ngIf="favorites === undefined || favorites?.length == 0">
     <p>
@@ -55,7 +80,7 @@
     </p>
   </div>
 
-  <div *ngIf="favorites !== undefined && favorites.length != 0" class="content">
+  <div *ngIf="favorites !== undefined && favorites.length != 0" class="grid-container">
     <ng-container *ngFor="let favorite of favorites">
 
       <mat-card class="listing"><!-- fxFlex="0 0 calc(100% / 4 - 30px)" -->

--- a/src/app/market/buy/buy.component.scss
+++ b/src/app/market/buy/buy.component.scss
@@ -1,45 +1,15 @@
 @import './src/assets/_config'; // import shared colors etc.
 @import './src/app/market/_order'; // order styles
 @import './src/app/wallet/shared/_filter-sorting'; // filtering & sorting
+@import './src/app/market/_product-card'; // listing item card preview
 
 // ------ UI ELEMENTS ------ //
 
+/*
 .mat-card {
   & > .title { // TODO: replace with %placeholders when Settings is merged
-    text-transform: uppercase;
-    font-weight: bold;
-    font-size: 13px;
+    @extend %box-title;
     margin: -4px 0 16px !important;
   }
 }
-
-
-// ------ LAYOUT ------ //
-
-
-// ------ FAVOURITES ------ //
-
-.favourites {
-  padding: $padding 30px $padding 5px;
-  .page-intro {
-    margin: -35px -30px 0 -5px;
-  }
-  .no-results {
-    margin: 0 0 35px 25px;
-  }
-  .grid-container {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: stretch;
-    .listing { // item (same as .content.listing in listings.component.scss)
-      margin: 0 0 25px 25px;
-      padding: 24px 16px 12px;
-      flex: 0 0 calc((100% / 4) - 57px); // default screen: 4 per row
-      max-width: calc((100% / 4) - 57px);
-      @include break-from(1650px) {
-        flex: 0 0 calc((100% / 6) - 57px); // larger: 6 per row
-        max-width: calc((100% / 6) - 57px);
-      }
-    }
-  }
-}
+*/

--- a/src/app/market/buy/buy.component.scss
+++ b/src/app/market/buy/buy.component.scss
@@ -20,11 +20,14 @@
 // ------ FAVOURITES ------ //
 
 .favourites {
-  padding: 30px 30px $padding 5px;
+  padding: $padding 30px $padding 5px;
+  .page-intro {
+    margin: -35px -30px 0 -5px;
+  }
   .no-results {
     margin: 0 0 35px 25px;
   }
-  .content {
+  .grid-container {
     display: flex;
     flex-wrap: wrap;
     align-items: stretch;

--- a/src/app/market/buy/buy.component.scss
+++ b/src/app/market/buy/buy.component.scss
@@ -22,7 +22,7 @@
 .favourites {
   padding: 30px 30px $padding 5px;
   .no-results {
-    margin: 0 10px;
+    margin: 0 0 35px 25px;
   }
   .content {
     display: flex;

--- a/src/app/market/buy/buy.component.scss
+++ b/src/app/market/buy/buy.component.scss
@@ -20,12 +20,23 @@
 // ------ FAVOURITES ------ //
 
 .favourites {
-  padding: 35px 20px;
+  padding: 30px 30px $padding 5px;
   .no-results {
     margin: 0 10px;
   }
-  .listing { // item
-    margin: 0 15px 30px;
-    padding: 24px 16px 12px;
+  .content {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: stretch;
+    .listing { // item (same as .content.listing in listings.component.scss)
+      margin: 0 0 25px 25px;
+      padding: 24px 16px 12px;
+      flex: 0 0 calc((100% / 4) - 57px); // default screen: 4 per row
+      max-width: calc((100% / 4) - 57px);
+      @include break-from(1650px) {
+        flex: 0 0 calc((100% / 6) - 57px); // larger: 6 per row
+        max-width: calc((100% / 6) - 57px);
+      }
+    }
   }
 }

--- a/src/app/market/buy/checkout-process/checkout-process.component.html
+++ b/src/app/market/buy/checkout-process/checkout-process.component.html
@@ -21,7 +21,7 @@
       <div class="no-results" [hidden]="cart?.shoppingCartItems.length != 0">
         <p>
           Oh no, your cart is empty! Let's fix this:<br>
-          <button mat-button color="primary" (click)="goToListings()">
+          <button mat-button (click)="goToListings()">
             <mat-icon class="icon" fontSet="partIcon" fontIcon="part-search"></mat-icon>
             Browse listings for sale
           </button>

--- a/src/app/market/buy/checkout-process/checkout-process.component.scss
+++ b/src/app/market/buy/checkout-process/checkout-process.component.scss
@@ -20,10 +20,8 @@ table {
 }
 
 .mat-card { // @ Shipping step
-  & > .title { // TODO: replace with %placeholders when Settings is merged
-    text-transform: uppercase;
-    font-weight: bold;
-    font-size: 13px;
+  & > .title {
+    @extend %box-title;
     margin: -4px 0 16px !important;
   }
 }
@@ -39,10 +37,20 @@ custom-icon { // overwrite of Material Stepper's step icons
 
 // ------ LAYOUT ------ //
 
+// for offsetting of Material's Stepper
+$custom-padding: ($padding - 24px);
+$custom-padding-l: ($padding-l - 24px);
+
 .container-block {
-  padding: 15px 15px 0;
+  padding: $custom-padding $custom-padding 0;
+  @include break(l) {
+    padding: $custom-padding-l $custom-padding-l 0;
+  }
   .no-results {
-    margin-top: 16px;
+    margin-top: $custom-padding;
+    @include break(l) {
+      margin-top: $custom-padding-l;
+    }
   }
 }
 
@@ -164,9 +172,7 @@ table.cart-items {
   line-height: 1.8;
   padding: 24px 30px;
   .title {
-    text-transform: uppercase;
-    font-weight: 500;
-    font-size: 13px;
+    @extend %box-title;
     color: $text;
   }
   .shipping-overview {
@@ -193,7 +199,7 @@ table.cart-items {
 // ------ SHIPPING ------ //
 
 .shipping {
-  margin-top: 16px;
+  margin-top: $custom-padding;
 }
 
 

--- a/src/app/market/listings/listings.component.html
+++ b/src/app/market/listings/listings.component.html
@@ -130,7 +130,7 @@
 
     <div class="no-results" [hidden]="!noMoreListings">
       <p>
-        Sorry, that's all folks!
+        That's all folks!
       </p>
     </div>
   </div><!-- .content -->

--- a/src/app/market/listings/listings.component.html
+++ b/src/app/market/listings/listings.component.html
@@ -83,7 +83,7 @@
   </div--><!-- .sidebar -->
 
   <!-- Do not remove the below class it is using for test case -->
-  <div class="content test-case-container"
+  <div class="content grid-container test-case-container"
        infiniteScroll
        [infiniteScrollContainer]="pagination.infinityScrollSelector"
        [fromRoot]="true"

--- a/src/app/market/listings/listings.component.scss
+++ b/src/app/market/listings/listings.component.scss
@@ -1,8 +1,10 @@
 @import './src/assets/_config'; // import shared colors etc.
+@import './src/app/market/_product-card'; // listing item card preview
 
 
 // ------ UI ELEMENTS ------ //
 
+/*
 .subtitle { // title
   @extend %subtitle;
   margin: 24px 0 14px;
@@ -10,9 +12,9 @@
     margin-top: 0;
   }
 }
+*/
 
 .container-block {
-  padding: $padding 30px $padding 5px; // temp fix until the sidebar will be shown again
   .content {
     width: 100%;
   }
@@ -21,7 +23,7 @@
 // ------ CONTROL BAR (top) ------ //
 
 .control-bar {
-  padding: 0 16px 0 35px; // offset filtering of reported items
+  padding: 0 16px 0 $padding; // offset filtering of reported items
   // search
   .search-listings {
     padding-right: 24px;
@@ -106,27 +108,10 @@
 
 // ------ CONTENT (right) ------ //
 
-.content {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: stretch;
-
-  .listing { // item (same as .grid-content.listing in buy.component.scss)
-    margin: 0 0 25px 25px;
-    padding: 24px 16px 12px;
-    flex: 0 0 calc((100% / 4) - 57px); // default screen: 4 per row
-    max-width: calc((100% / 4) - 57px);
-    @include break-from(1650px) {
-      flex: 0 0 calc((100% / 6) - 57px); // larger: 6 per row
-      max-width: calc((100% / 6) - 57px);
-    }
-  }
-
-}
-
 .no-results {
   width: 100%;
-  margin: 0 0 30px 25px;
+  margin: 24px 0 0 0;
+  padding: 50px 0;
 }
 
 button.previous-page {

--- a/src/app/market/listings/listings.component.scss
+++ b/src/app/market/listings/listings.component.scss
@@ -111,7 +111,7 @@
   flex-wrap: wrap;
   align-items: stretch;
 
-  .listing { // item (same as .content.listing in buy.component.scss)
+  .listing { // item (same as .grid-content.listing in buy.component.scss)
     margin: 0 0 25px 25px;
     padding: 24px 16px 12px;
     flex: 0 0 calc((100% / 4) - 57px); // default screen: 4 per row

--- a/src/app/market/listings/listings.component.scss
+++ b/src/app/market/listings/listings.component.scss
@@ -12,7 +12,7 @@
 }
 
 .container-block {
-  padding: $padding $padding $padding 5px; // temp fix until the sidebar will be shown again
+  padding: $padding 30px $padding 5px; // temp fix until the sidebar will be shown again
   .content {
     width: 100%;
   }
@@ -111,7 +111,7 @@
   flex-wrap: wrap;
   align-items: stretch;
 
-  .listing { // item
+  .listing { // item (same as .content.listing in buy.component.scss)
     margin: 0 0 25px 25px;
     padding: 24px 16px 12px;
     flex: 0 0 calc((100% / 4) - 57px); // default screen: 4 per row
@@ -126,7 +126,7 @@
 
 .no-results {
   width: 100%;
-  margin: 0 0 30px 30px;
+  margin: 0 0 30px 25px;
 }
 
 button.previous-page {

--- a/src/app/market/listings/preview-listing/preview-listing.component.scss
+++ b/src/app/market/listings/preview-listing/preview-listing.component.scss
@@ -185,8 +185,6 @@ p.description {
   &.detailed {
     @extend %enable-select;
     white-space: pre-line;
-    column-count: 2;
-    column-gap: 30px;
   }
 }
 

--- a/src/app/market/sell/sell.component.html
+++ b/src/app/market/sell/sell.component.html
@@ -23,6 +23,19 @@
 
 <div class="container-block with-tab-bar" *ngIf="tabLabels[selectedTab] == 'listings'">
 
+  <div class="page-intro">
+    <h1>Your Listings</h1>
+    <div class="content">
+      <p>
+        This is your starting point and administrative center for selling your Products on the Market.<br>
+        Create new Listings here and track their orders in Order tab.
+      </p>
+      <p class="widget-help">
+        Note: All Listings created here will be available publicly on Particl Open Market.
+      </p>
+    </div>
+  </div><!-- .page-intro -->
+
   <!-- Listings > Filter -->
   <div class="filter">
 
@@ -120,5 +133,18 @@
 <!-- =========== ORDERS =========== -->
 <!-- Do not remove the below class it is using for test case -->
 <div class="container-block with-tab-bar test-case-container" *ngIf="tabLabels[selectedTab] == 'orders'">
+
+  <div class="page-intro">
+    <h1>Selling orders</h1>
+    <div class="content">
+      <p>
+        This is where you manage your Selling orders (orders from Buyers on your published Listings).
+      </p>
+      <p class="widget-help">
+        Each Order advancement needs to be confirmed on this page, e.g. accepting/rejecting bids, locking funds to escrow &amp; marking Orders as shipped.
+      </p>
+    </div>
+  </div><!-- .page-intro -->
+
   <app-orders type="sell"></app-orders>
 </div><!-- "Orders" tab -->

--- a/src/app/market/sell/sell.component.html
+++ b/src/app/market/sell/sell.component.html
@@ -27,11 +27,11 @@
     <h1>Your Listings</h1>
     <div class="content">
       <p>
-        This is your starting point and administrative center for selling your Products on the Market.<br>
-        Create new Listings here and track their orders in Order tab.
+        This is your dashboard for selling your products on the marketplace and manage their listings.<br>
+        Create new listings and manage them here. Use the Orders tab to track and process orders from your customers.
       </p>
       <p class="widget-help">
-        Note: All Listings created here will be available publicly on Particl Open Market.
+        Note: All listings created here will be publicly available on the marketplace.
       </p>
     </div>
   </div><!-- .page-intro -->
@@ -135,13 +135,13 @@
 <div class="container-block with-tab-bar test-case-container" *ngIf="tabLabels[selectedTab] == 'orders'">
 
   <div class="page-intro">
-    <h1>Selling orders</h1>
+    <h1>Sell Orders</h1>
     <div class="content">
       <p>
-        This is where you manage your Selling orders (orders from Buyers on your published Listings).
+        This is where you manage the orders you're in the process of selling to your customers.
       </p>
       <p class="widget-help">
-        Each Order advancement needs to be confirmed on this page, e.g. accepting/rejecting bids, locking funds to escrow &amp; marking Orders as shipped.
+        Each step of the selling process needs to be confirmed in this page (i.e. marking an order as "Shipped").
       </p>
     </div>
   </div><!-- .page-intro -->

--- a/src/app/market/sell/seller-listing/seller-listing.component.html
+++ b/src/app/market/sell/seller-listing/seller-listing.component.html
@@ -8,11 +8,9 @@
         <div class="name">{{ listing?.title }}</div>
         <div class="categories">{{ listing?.category.name }}</div>
         <div class="date">
-          <!--span class="hash" matTooltip="Order hash">AGR</span-->
           Added {{ listing?.createdAt }}
           <br>
           {{ listing?.expiredAt }} 
-          <!-- &bull; <span class="to-do">Expires 2018-02-13</span> -->
         </div>
       </div>
       <div *ngFor="let status of getStatus(listing?.status)">
@@ -38,8 +36,8 @@
         <!--tr><th>Quantity</th><td>2</td></tr-->
         <tr>
           <th>Price per item</th>
-          <td>{{ listing?.basePrice.getIntegerPart() }} {{ listing?.basePrice.dot() }}
-            <small>{{ listing?.basePrice.getFractionalPart() }}</small>
+          <td>
+            {{ listing?.basePrice.getIntegerPart() }}{{ listing?.basePrice.dot() }}<small>{{ listing?.basePrice.getFractionalPart() }}</small>
             PART
           </td>
         </tr>

--- a/src/app/wallet/overview/widgets/coldstake/revert-coldstaking/revert-coldstaking.component.scss
+++ b/src/app/wallet/overview/widgets/coldstake/revert-coldstaking/revert-coldstaking.component.scss
@@ -1,1 +1,5 @@
 @import './src/assets/_config'; // import shared colors etc.
+
+.mat-dialog-content {
+  max-width: 40rem;
+}

--- a/src/app/wallet/overview/widgets/coldstake/zap-coldstaking/zap-coldstaking.component.scss
+++ b/src/app/wallet/overview/widgets/coldstake/zap-coldstaking/zap-coldstaking.component.scss
@@ -1,1 +1,5 @@
 @import './src/assets/_config'; // import shared colors etc.
+
+.mat-dialog-content {
+  max-width: 40rem;
+}

--- a/src/app/wallet/proposals/proposal-details/proposal-details.component.scss
+++ b/src/app/wallet/proposals/proposal-details/proposal-details.component.scss
@@ -75,7 +75,7 @@
         @extend %enable-select;
         color: $text-muted;
         white-space: pre-line;
-        word-break: break-all;
+        word-break: break-word;
       }
       /*
       .authors {

--- a/src/app/wallet/proposals/proposals.component.html
+++ b/src/app/wallet/proposals/proposals.component.html
@@ -30,10 +30,11 @@
     <h1>Community Proposals</h1>
     <div class="content">
       <p>
-        Proposals are suggestions submitted by Particl Community.<br>
+        As part of Particl's decentralized governance mechanism, you can submit and vote on any Particl-related proposal.<br>
+        Once a proposal is submitted, every PART holder can vote on it.
       </p>
       <p class="widget-help">
-        Every PART owner can cast their vote on each Proposal &ndash; the weight of their vote equals to amount of coins owned.
+        Anyone can submit and vote on proposals in a provably fair manner. The weight of your vote is equal to your PART balance.
       </p>
     </div>
   </div><!-- .page-intro -->
@@ -83,10 +84,6 @@
       </mat-card>
     </div> -->
     <!-- .search-sorting -->
-
-    <p class="widget-help">
-      As a part of our decentralized governance, Proposals let any user suggest changes to anything related to Particl. Once proposal is submitted, every Particl owner can vote on it.
-    </p>
 
   </div><!-- .sidebar -->
 

--- a/src/app/wallet/proposals/proposals.component.html
+++ b/src/app/wallet/proposals/proposals.component.html
@@ -24,7 +24,20 @@
 </app-header>
 
 
-<div class="container-block with-tab-bar">  
+<div class="container-block with-tab-bar">
+
+  <div class="page-intro">
+    <h1>Community Proposals</h1>
+    <div class="content">
+      <p>
+        Proposals are suggestions submitted by Particl Community.<br>
+      </p>
+      <p class="widget-help">
+        Every PART owner can cast their vote on each Proposal &ndash; the weight of their vote equals to amount of coins owned.
+      </p>
+    </div>
+  </div><!-- .page-intro -->
+
   <div class="filter">
 
     <div class="new-proposal">

--- a/src/app/wallet/wallet/send/send.component.html
+++ b/src/app/wallet/wallet/send/send.component.html
@@ -27,212 +27,238 @@
 </app-header>
 
 
-<div class="container-block with-tab-bar" fxLayout="row" fxLayoutGap="35px">
+<div class="container-block with-tab-bar">
 
-  <div class="from-box" fxFlex="0 0 320px">
-    <div class="sticky">
-      <div class="section-title">Pay from</div>
-      <mat-card>
-        <!-- Select "FROM" balance/account -->
-        <mat-radio-group class="from-balance-type block-radio" name="sendInput" [(ngModel)]="send.input" 
-                          fxLayout="column" fxLayoutGap="10px" (change)="updateAmount()">
-          <mat-radio-button class="balance" value="part" checked="checked" color="primary"
-                            (change)="setInputOutput('part', 'output')" fxFlex >
-            <div class="name">Public</div>
-            <div class="desc">Available balance:<span class="amount">{{ getBalance('part') }}</span></div>
-          </mat-radio-button>
-          <mat-radio-button class="balance" value="blind" fxFlex color="primary" (change)="setInputOutput('blind', 'output')" >
-            <div class="name">Blind</div>
-            <div class="desc">Available balance:<span *ngIf="!checkBalance('blind')" class="amount">{{ getBalance('blind') }}</span>
-              <mat-icon *ngIf="checkBalance('blind')" fontSet="partIcon" fontIcon="part-circle-question" class="help-icon"
-                        matTooltip="It is normal to have a very small balance in Blind even after transferring out everything. This is due to the way CT works and part of the privacy platform."></mat-icon>
-            </div>
-          </mat-radio-button>
-          <mat-radio-button *ngIf="testnet" class="balance" value="anon" color="primary" (change)="setInputOutput('anon', 'output')" fxFlex >
-            <div class="name">Anon</div>
-            <div class="desc">Available balance:<span class="amount">{{ getBalance('anon') }}</span></div>
-          </mat-radio-button>
-        </mat-radio-group><!-- .from-balance-type -->
-  
-        <!-- TX info help -->
-        <p class="widget-help" *ngIf="send.input === 'part'">
-          In public transactions, everything is visible on the blockchain &ndash; transaction amount, sender and receiver addresses.
-        </p>
-        <p class="widget-help" *ngIf="send.input === 'blind'">
-          Blinded transactions hide transaction amounts, but the sender and receiver addresses are still visible.
-        </p>
-        <p class="widget-help" *ngIf="send.input === 'anon'">
-          Anon transaction offer the highest privacy &ndash; transaction amounts and not even sender and receiver
-          addresses are publicly visible. The higher privacy level is, the larger fee needs to be paid. Advanced users can further adjust the number of ring signatures.
-        </p>
-  
-        <!-- Show privacy slider if anonymous TX -->
-        <div *ngIf="send.input === 'anon' && advanced" class="advanced">
-          <div class="subtitle">Privacy level <small>(no. of ring sigs)</small></div>
-          <div class="privacy-level">
-            <div class="privacy-labels" fxLayout="row" fxLayoutAlign="space-between center">
-              <span
-                fxFlex="0 0 50px"
-                class="privacy-label low"
-                (click)="setPrivacy(4)"
-                matTooltip="Set low privacy"
-                matTooltipPosition="below">Low
-              </span>
-              <span
-                fxFlex="0 0 50px"
-                class="privacy-label high"
-                (click)="setPrivacy(16)"
-                matTooltip="Set high privacy"
-                matTooltipPosition="below">High
-              </span>
-              <span
-                fxFlex="0 0 50px"
-                class="privacy-label highest"
-                (click)="setPrivacy(32)"
-                matTooltip="Set highest privacy"
-                matTooltipPosition="below">Highest
-              </span>
-            </div><!-- .privacy-labels -->
-  
-            <mat-slider
-              thumbLabel
-              color="primary"
-              [min]="3"
-              (change)="onSlide($event)"
-              [max]="32"
-              [value]="send.ringsize">
-            </mat-slider>
-  
-            <!-- set default value after clicking the button (8 signatures?) -->
-            <button
-              (click)="setPrivacy(8)"
-              mat-button
-              class="small"
-              matTooltip="Set default, recommended privacy level">
-              <mat-icon fontSet="partIcon" fontIcon="part-anon"></mat-icon>
-              Auto privacy
-            </button>
-          </div><!-- .privacy-level -->
-        </div><!-- /if Anon -->
-      </mat-card>
+  <div class="page-intro">
+    <h1 *ngIf="type === 'sendPayment'">Send payment</h1>
+    <h1 *ngIf="type === 'balanceTransfer'">Convert balances</h1>
+    <div class="content">
+      <p *ngIf="type === 'sendPayment'">
+        Send payments to anyone.<br>
+        You can adjust the level of privacy of your transactions by selecting balances listed in "Pay from".
+      </p>
+      <p *ngIf="type === 'balanceTransfer'">
+        Convert your coins between public and private balances.<br>
+        To increase your level of privacy, it's recommended to always keep some of your coins in private balances (Blind &amp; Anon).
+      </p>
+      <p class="widget-help">
+        What are the differences between Blind and Anon balances? How do they affect my privacy? Learn more on Particl Wiki:
+        <a mat-button href="https://particl.wiki/currency-types" class="small">
+          <mat-icon fontSet="partIcon" fontIcon="part-wikipedia"></mat-icon>
+          Currency &amp; transaction types
+        </a>
+      </p>
     </div>
-  </div><!-- .from-box -->
+  </div><!-- .page-intro -->
 
-
-
-  <div class="to-box" fxFlex="1 1 100%">
-    <form name="walletSendForm">
-
-      <!-- Select "TO" balance/account (ONLY for Balance transfer) -->
-      <div class="section-title" *ngIf="type === 'balanceTransfer'">
-        Convert to
+  <div fxLayout="row" fxLayoutGap="35px">
+  
+    <div class="from-box" fxFlex="0 0 320px">
+      <div class="sticky">
+        <div class="section-title">Pay from</div>
+        <mat-card>
+          <!-- Select "FROM" balance/account -->
+          <mat-radio-group class="from-balance-type block-radio" name="sendInput" [(ngModel)]="send.input" 
+                            fxLayout="column" fxLayoutGap="10px" (change)="updateAmount()">
+            <mat-radio-button class="balance" value="part" checked="checked" color="primary"
+                              (change)="setInputOutput('part', 'output')" fxFlex >
+              <div class="name">Public</div>
+              <div class="desc">Available balance:<span class="amount">{{ getBalance('part') }}</span></div>
+            </mat-radio-button>
+            <mat-radio-button class="balance" value="blind" fxFlex color="primary" (change)="setInputOutput('blind', 'output')" >
+              <div class="name">Blind</div>
+              <div class="desc">Available balance:<span *ngIf="!checkBalance('blind')" class="amount">{{ getBalance('blind') }}</span>
+                <mat-icon *ngIf="checkBalance('blind')" fontSet="partIcon" fontIcon="part-circle-question" class="help-icon"
+                          matTooltip="It is normal to have a very small balance in Blind even after transferring out everything. This is due to the way CT works and part of the privacy platform."></mat-icon>
+              </div>
+            </mat-radio-button>
+            <mat-radio-button *ngIf="testnet" class="balance" value="anon" color="primary" (change)="setInputOutput('anon', 'output')" fxFlex >
+              <div class="name">Anon</div>
+              <div class="desc">Available balance:<span class="amount">{{ getBalance('anon') }}</span></div>
+            </mat-radio-button>
+          </mat-radio-group><!-- .from-balance-type -->
+    
+          <!-- TX info help -->
+          <p class="widget-help" *ngIf="send.input === 'part'">
+            In public transactions, everything is visible on the blockchain &ndash; transaction amount, sender and receiver addresses.
+          </p>
+          <p class="widget-help" *ngIf="send.input === 'blind'">
+            Blinded transactions hide transaction amounts, but the sender and receiver addresses are still visible.
+          </p>
+          <p class="widget-help" *ngIf="send.input === 'anon'">
+            Anon transaction offer the highest privacy &ndash; transaction amounts and not even sender and receiver
+            addresses are publicly visible. The higher privacy level is, the larger fee needs to be paid. Advanced users can further adjust the number of ring signatures.
+          </p>
+    
+          <!-- Show privacy slider if anonymous TX -->
+          <div *ngIf="send.input === 'anon' && advanced" class="advanced">
+            <div class="subtitle">Privacy level <small>(no. of ring sigs)</small></div>
+            <div class="privacy-level">
+              <div class="privacy-labels" fxLayout="row" fxLayoutAlign="space-between center">
+                <span
+                  fxFlex="0 0 50px"
+                  class="privacy-label low"
+                  (click)="setPrivacy(4)"
+                  matTooltip="Set low privacy"
+                  matTooltipPosition="below">Low
+                </span>
+                <span
+                  fxFlex="0 0 50px"
+                  class="privacy-label high"
+                  (click)="setPrivacy(16)"
+                  matTooltip="Set high privacy"
+                  matTooltipPosition="below">High
+                </span>
+                <span
+                  fxFlex="0 0 50px"
+                  class="privacy-label highest"
+                  (click)="setPrivacy(32)"
+                  matTooltip="Set highest privacy"
+                  matTooltipPosition="below">Highest
+                </span>
+              </div><!-- .privacy-labels -->
+    
+              <mat-slider
+                thumbLabel
+                color="primary"
+                [min]="3"
+                (change)="onSlide($event)"
+                [max]="32"
+                [value]="send.ringsize">
+              </mat-slider>
+    
+              <!-- set default value after clicking the button (8 signatures?) -->
+              <button
+                (click)="setPrivacy(8)"
+                mat-button
+                class="small"
+                matTooltip="Set default, recommended privacy level">
+                <mat-icon fontSet="partIcon" fontIcon="part-anon"></mat-icon>
+                Auto privacy
+              </button>
+            </div><!-- .privacy-level -->
+          </div><!-- /if Anon -->
+        </mat-card>
       </div>
-      <mat-card class="section to-balance-type" *ngIf="type === 'balanceTransfer'">
-        <mat-radio-group class="to-balance-type block-radio" name="sendOutput" [(ngModel)]="send.output"
-                         fxLayout="column" fxLayoutGap="10px" (change)="updateAmount()">
-          <mat-radio-button class="balance" value="part" color="primary" (change)="setInputOutput('part', 'input')" checked="checked" fxFlex [disabled]="send.input === 'part'">
-            <div class="name">Public</div>
-            <div class="desc">Available balance:<span class="amount">{{ getBalance('part') }}</span></div>
-          </mat-radio-button>
-          <mat-radio-button class="balance" value="blind" color="primary" (change)="setInputOutput('blind', 'input')" [disabled]="send.input === 'blind'" fxFlex>
-            <div class="name">Blind</div>
-            <div class="desc">Available balance:<span *ngIf="!checkBalance('blind')"
-                                            class="amount">{{ getBalance('blind') }}</span>
-              <mat-icon *ngIf="checkBalance('blind')" fontSet="partIcon" fontIcon="part-circle-question"
-                        class="help-icon"
-                        matTooltip="It is normal to have a very small balance in Blind even after transferring out everything. This is due to the way CT works and part of the privacy platform."></mat-icon>
+    </div><!-- .from-box -->
+
+
+
+    <div class="to-box" fxFlex="1 1 100%">
+      <form name="walletSendForm">
+
+        <!-- Select "TO" balance/account (ONLY for Balance transfer) -->
+        <div class="section-title" *ngIf="type === 'balanceTransfer'">
+          Convert to
+        </div>
+        <mat-card class="section to-balance-type" *ngIf="type === 'balanceTransfer'">
+          <mat-radio-group class="to-balance-type block-radio" name="sendOutput" [(ngModel)]="send.output"
+                          fxLayout="column" fxLayoutGap="10px" (change)="updateAmount()">
+            <mat-radio-button class="balance" value="part" color="primary" (change)="setInputOutput('part', 'input')" checked="checked" fxFlex [disabled]="send.input === 'part'">
+              <div class="name">Public</div>
+              <div class="desc">Available balance:<span class="amount">{{ getBalance('part') }}</span></div>
+            </mat-radio-button>
+            <mat-radio-button class="balance" value="blind" color="primary" (change)="setInputOutput('blind', 'input')" [disabled]="send.input === 'blind'" fxFlex>
+              <div class="name">Blind</div>
+              <div class="desc">Available balance:<span *ngIf="!checkBalance('blind')"
+                                              class="amount">{{ getBalance('blind') }}</span>
+                <mat-icon *ngIf="checkBalance('blind')" fontSet="partIcon" fontIcon="part-circle-question"
+                          class="help-icon"
+                          matTooltip="It is normal to have a very small balance in Blind even after transferring out everything. This is due to the way CT works and part of the privacy platform."></mat-icon>
+              </div>
+            </mat-radio-button>
+            <mat-radio-button *ngIf="testnet" class="balance" value="anon" color="primary" (change)="setInputOutput('anon', 'input')" [disabled]="send.input === 'anon'" fxFlex>
+              <div class="name">Anon</div>
+              <div class="desc">Available balance:<span class="amount">{{ getBalance('anon') }}</span></div>
+            </mat-radio-button>
+          </mat-radio-group><!-- .from-balance-type -->
+          <p class="widget-help">
+            Balance transfer helps you convert your PART between Public and Private balances.
+          </p>
+        </mat-card>
+
+
+        <div class="section-title" *ngIf="type === 'sendPayment' || advanced">
+          Pay to
+        </div>
+        <mat-card class="pay-to" *ngIf="type === 'sendPayment' || advanced">
+
+          <!-- Receiver's address/label -->
+          <div class="section receiver-address">
+            <div fxLayout="row" fxLayoutAlign="center center" fxLayoutGap="15px">
+              <mat-form-field fxFlex="1 1 100%" class="full-width larger">
+                <input #address name="toAddress" matInput
+                      [ngClass]="{'verify-sucess': checkAddress() === true, 'verify-error': checkAddress() === false }"
+                      type="text" placeholder="Receiver's address" [(ngModel)]="send.toAddress"
+                      (ngModelChange)="verifyAddress()"/>
+              </mat-form-field>
+              <span fxFlex="0 0 16px">
+                <mat-icon class="cursor-pointer" matTooltip="Pick from Address Book" (click)="openLookup()"
+                          fontSet="partIcon" fontIcon="part-people"></mat-icon>
+              </span>
+              <span fxFlex="0 0 16px">
+                <mat-icon class="cursor-pointer" matTooltip="Paste" fontSet="partIcon" fontIcon="part-past"
+                          (click)="pasteAddress()"></mat-icon>
+              </span>
+              <span fxFlex="0 0 16px">
+                <mat-icon class="cursor-pointer" matTooltip="Clear all" (click)="clearReceiver()"
+                          color="warn" fontSet="partIcon" fontIcon="part-clear-all"></mat-icon>
+              </span>
             </div>
-          </mat-radio-button>
-          <mat-radio-button *ngIf="testnet" class="balance" value="anon" color="primary" (change)="setInputOutput('anon', 'input')" [disabled]="send.input === 'anon'" fxFlex>
-            <div class="name">Anon</div>
-            <div class="desc">Available balance:<span class="amount">{{ getBalance('anon') }}</span></div>
-          </mat-radio-button>
-        </mat-radio-group><!-- .from-balance-type -->
-        <p class="widget-help">
-          Balance transfer helps you convert your PART between Public and Private balances.
-        </p>
-      </mat-card>
-
-
-      <div class="section-title" *ngIf="type === 'sendPayment' || advanced">
-        Pay to
-      </div>
-      <mat-card class="pay-to" *ngIf="type === 'sendPayment' || advanced">
-
-        <!-- Receiver's address/label -->
-        <div class="section receiver-address">
-          <div fxLayout="row" fxLayoutAlign="center center" fxLayoutGap="15px">
-            <mat-form-field fxFlex="1 1 100%" class="full-width larger">
-              <input #address name="toAddress" matInput
-                     [ngClass]="{'verify-sucess': checkAddress() === true, 'verify-error': checkAddress() === false }"
-                     type="text" placeholder="Receiver's address" [(ngModel)]="send.toAddress"
-                     (ngModelChange)="verifyAddress()"/>
+            <mat-form-field class="full-width larger no-top-padding" floatPlaceholder="never">
+              <input name="toLabel" matInput type="text" placeholder="Receiver's name (optional)"
+                    [(ngModel)]="send.toLabel">
             </mat-form-field>
-            <span fxFlex="0 0 16px">
-              <mat-icon class="cursor-pointer" matTooltip="Pick from Address Book" (click)="openLookup()"
-                        fontSet="partIcon" fontIcon="part-people"></mat-icon>
-            </span>
-            <span fxFlex="0 0 16px">
-              <mat-icon class="cursor-pointer" matTooltip="Paste" fontSet="partIcon" fontIcon="part-past"
-                        (click)="pasteAddress()"></mat-icon>
-            </span>
-            <span fxFlex="0 0 16px">
-              <mat-icon class="cursor-pointer" matTooltip="Clear all" (click)="clearReceiver()"
-                        color="warn" fontSet="partIcon" fontIcon="part-clear-all"></mat-icon>
-            </span>
-          </div>
-          <mat-form-field class="full-width larger no-top-padding" floatPlaceholder="never">
-            <input name="toLabel" matInput type="text" placeholder="Receiver's name (optional)"
-                   [(ngModel)]="send.toLabel">
+            <p class="widget-help">
+              You can save Receiver's address to your Address book by labeling it here.
+            </p>
+          </div><!-- .receiver-address.section -->
+
+          <!-- Narrations -->
+          <div class="section narration advanced" *ngIf="advanced">
+            <mat-form-field class="full-width larger" floatPlaceholder="never">
+              <input #narration type="text" matInput name="sendNote" placeholder="Narration (optional)" maxlength="24"
+                    [(ngModel)]="send.narration">
+              <mat-hint align="end">{{narration.value.length}} / 24</mat-hint>
+            </mat-form-field>
+            <p class="widget-help">
+              Send a short note with your payment. Keep in mind that when sending to Public addresses, the narrations will be recorded and publicly visible on the blockchain. Blind & Anon transactions make narrations visible only for Sender and Receiver.
+            </p>
+          </div><!-- .narration.section -->
+        </mat-card><!-- .pay-to -->
+
+        <!-- Send amount % buttons -->
+        <mat-card class="send-amount" fxLayout="row" fxLayoutGap="15px" fxLayoutAlign="start center">
+          <mat-form-field fxFlex="0 0 150px">
+            <!-- Send amount -->
+            <input matInput type="text" name="sendAmount" placeholder="Amount to send" [(ngModel)]="send.amount"
+                  (input)="verifyAmount()"
+                  [ngClass]="{'verify-sucess': checkAmount() === true, 'verify-error': checkAmount() === false }"
+                  [disabled]="send.subtractFeeFromAmount">
           </mat-form-field>
-          <p class="widget-help">
-            You can save Receiver's address to your Address book by labeling it here.
-          </p>
-        </div><!-- .receiver-address.section -->
-
-        <!-- Narrations -->
-        <div class="section narration advanced" *ngIf="advanced">
-          <mat-form-field class="full-width larger" floatPlaceholder="never">
-            <input #narration type="text" matInput name="sendNote" placeholder="Narration (optional)" maxlength="24"
-                   [(ngModel)]="send.narration">
-            <mat-hint align="end">{{narration.value.length}} / 24</mat-hint>
-          </mat-form-field>
-          <p class="widget-help">
-            Send a short note with your payment. Keep in mind that when sending to Public addresses, the narrations will be recorded and publicly visible on the blockchain. Blind & Anon transactions make narrations visible only for Sender and Receiver.
-          </p>
-        </div><!-- .narration.section -->
-      </mat-card><!-- .pay-to -->
-
-      <!-- Send amount % buttons -->
-      <mat-card class="send-amount" fxLayout="row" fxLayoutGap="15px" fxLayoutAlign="start center">
-        <mat-form-field fxFlex="0 0 150px">
-          <!-- Send amount -->
-          <input matInput type="text" name="sendAmount" placeholder="Amount to send" [(ngModel)]="send.amount"
-                 (input)="verifyAmount()"
-                 [ngClass]="{'verify-sucess': checkAmount() === true, 'verify-error': checkAmount() === false }"
-                 [disabled]="send.subtractFeeFromAmount">
-        </mat-form-field>
-        <mat-checkbox name="send_all" [(ngModel)]="send.subtractFeeFromAmount" (click)="sendAllBalance()"
-                      class="send-all" color="warn">
-          Send All
-        </mat-checkbox>
-        <!-- Choose currency -->
-        <mat-select class="underlining-select" fxFlex="0 0 70px" name="currency" [(ngModel)]="send.currency"
-                    placeholder="Currency">
-          <mat-option value="part">PART</mat-option>
-        </mat-select>
-        <!-- Send buttons -->
-        <div class="actions" fxFlex="1 1 100%">
-          <button mat-raised-button color="primary" class="validate" (click)="onSubmit()"
-                  [disabled]="!checkAddress() || !checkAmount()">
-            <mat-icon fontSet="partIcon" fontIcon="part-check"></mat-icon>
-            Make payment
-          </button>
-        </div><!-- .actions -->
-      </mat-card><!-- .send-amount -->
+          <mat-checkbox name="send_all" [(ngModel)]="send.subtractFeeFromAmount" (click)="sendAllBalance()"
+                        class="send-all" color="warn">
+            Send All
+          </mat-checkbox>
+          <!-- Choose currency -->
+          <mat-select class="underlining-select" fxFlex="0 0 70px" name="currency" [(ngModel)]="send.currency"
+                      placeholder="Currency">
+            <mat-option value="part">PART</mat-option>
+          </mat-select>
+          <!-- Send buttons -->
+          <div class="actions" fxFlex="1 1 100%">
+            <button mat-raised-button color="primary" class="validate" (click)="onSubmit()"
+                    [disabled]="!checkAddress() || !checkAmount()">
+              <mat-icon fontSet="partIcon" fontIcon="part-check"></mat-icon>
+              Make payment
+            </button>
+          </div><!-- .actions -->
+        </mat-card><!-- .send-amount -->
 
 
-    </form><!-- walletSendForm -->
-  </div><!-- .to-box -->
+      </form><!-- walletSendForm -->
+    </div><!-- .to-box -->
+
+  </div><!-- flex row -->
 
 </div><!-- .container -->

--- a/src/app/wallet/wallet/send/send.component.scss
+++ b/src/app/wallet/wallet/send/send.component.scss
@@ -17,6 +17,7 @@
 
 .section-title { // 'Pay from/to, Convert' etc.
   @extend %subtitle;
+  margin-top: 0;
 }
 
 .subtitle { // subtitles (eg. 'privacy level' in anon
@@ -79,10 +80,6 @@
 
 
 // ------ LAYOUT ------ //
-
-.container-block {
-  padding-top: 0; // offset subtitles
-}
 
 .from-box { // 'pay from..'
   .sticky {

--- a/src/assets/_config.scss
+++ b/src/assets/_config.scss
@@ -76,6 +76,10 @@ $break-xhd: 2200px;
   opacity: 0.55;
 }
 
+%lightest { // light "grey" text
+  opacity: 0.36;
+}
+
 %reset {
   opacity: 1;
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -237,16 +237,19 @@ body {
 
 .no-results {
   font-size: 18px;
-  color: darken($bg-shadow, 15%);
   text-transform: uppercase;
   text-align: center;
   padding: 170px 0;
   border: 2px dashed $bg-shadow;
   background: rgba($color-white, 0.5);
+  p {
+    @extend %lightest;
+  }
   button {
     margin-top: 12px;
   }
   .widget-help {
+    @extend %reset;
     margin: 0;
     text-transform: none;
     font-size: 12px;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -156,6 +156,9 @@ body {
   }
   .content {
     margin-top: 16px;
+    p {
+      line-height: 1.5;
+    }
   }
   .widget-help {
     margin-bottom: 0;


### PR DESCRIPTION
- removed 2 columns from Listing's preview (as per [PBD-92](https://particl.atlassian.net/browse/PBD-92), fixes #1427)
- Favourites: fixed layout
- Zapping modals: adjusted modal width
- page titles: added to more pages (@particl/marketing-team can I ask for proof-reading again? - [all titles here](https://imgur.com/a/fivWkOv) :)

### TODO @AllienWorks 

- [x] further tweak & unify Listings/Favourites layout
- [x] fix page title description line height
- [x] add more titles?
- [x] Send: add button "learn more about different Balances and transaction types" with link to Wiki
- [ ] Sell > Listings: fix loading overlay
- [x] Proposals: change desc to `break-word` (see [PBD-224](https://particl.atlassian.net/browse/PBD-224))