### PR TITLE
Fixes electron renderer restart resulting in Angular RPC calls failing.

### DIFF
--- a/main.js
+++ b/main.js
@@ -110,6 +110,13 @@ function initMainWindow() {
   mainWindow.setMenuBarVisibility(false);
   mainWindow.setAutoHideMenuBar(true);
 
+  // Setup configuration listener
+  //    Needs to be included here because init.js is only created once (when the app is ready)
+  //    Since the config contains an emitter and a listener based on the browserWindow object,
+  //    it needs to be updated with a new BrowserWindow context when the main window is destroyed and re-created
+  //    (a la OSX, <sarcasm> thanks Apple for your unique behaviour </sarcasm> )
+  daemonConfig.init(mainWindow);
+
   // and load the index.html of the app.
   if (options.dev) {
     mainWindow.loadURL('http://localhost:4200');
@@ -139,13 +146,6 @@ function initMainWindow() {
     // when you should delete the corresponding element.
     mainWindow = null
   });
-
-  // Setup configuration listener
-  //    Needs to be included here because init.js is only created once (when the app is ready)
-  //    Since the config contains an emitter and a listener based on the browserWindow object,
-  //    it needs to be updated with a new BrowserWindow context when the main window is destroyed and re-created
-  //    (a la OSX, <sarcasm> thanks Apple for your unique behaviour </sarcasm> )
-  daemonConfig.init(mainWindow);
 }
 
 /*

--- a/main.js
+++ b/main.js
@@ -21,10 +21,12 @@ if (process.platform === 'linux') {
 if (app.getVersion().includes('testnet'))
   process.argv.push(...['-testnet']);
 
-const options = require('./modules/daemon/daemonConfig').getConfiguration();
+const daemonConfig = require('./modules/daemon/daemonConfig');
 const log     = require('./modules/logger').init();
 const init    = require('./modules/init');
 const _auth = require('./modules/webrequest/http-auth');
+
+const options = daemonConfig.getConfiguration();
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -137,6 +139,13 @@ function initMainWindow() {
     // when you should delete the corresponding element.
     mainWindow = null
   });
+
+  // Setup configuration listener
+  //    Needs to be included here because init.js is only created once (when the app is ready)
+  //    Since the config contains an emitter and a listener based on the browserWindow object,
+  //    it needs to be updated with a new BrowserWindow context when the main window is destroyed and re-created
+  //    (a la OSX, <sarcasm> thanks Apple for your unique behaviour </sarcasm> )
+  daemonConfig.init(mainWindow);
 }
 
 /*

--- a/modules/daemon/daemonConfig.js
+++ b/modules/daemon/daemonConfig.js
@@ -14,7 +14,9 @@ if (isEmptyObject(_options)) {
 }
 
 const conFilePath = path.join( cookie.getParticlPath(_options), 'particl.conf');
-const IPC_CHANNEL = 'rpc-configuration';
+const IPC_CHANNEL_PUB = 'rpc-configuration';
+const IPC_CHANNEL_LISTEN = 'request-configuration';
+
 const SAFE_KEYS = ['addressindex'];
 
 let STORED_CONFIGURATION = {};
@@ -258,36 +260,11 @@ const getConfiguration = () => {
 }
 
 
-const initializeIpcListener = (mainWindow) => {
-  if (mainWindowRef === null) {
-    mainWindowRef = mainWindow;
-  }
-  removeIpcListener();
-
-  rxIpc.registerListener(IPC_CHANNEL, () => {
-    let settings = getConfiguration();
-    return Observable.create(observer => {
-      observer.next(settings);
-      observer.complete();
-    });
-  });
-}
-
-
-const removeIpcListener = () => {
-  rxIpc.removeListeners(IPC_CHANNEL);
-}
-
-
 const emitConfiguration = () => {
   let settings = getConfiguration();
 
-  if (!settings.auth) {
-    setTimeout(emitConfiguration, 1000);
-    return;
-  }
   try {
-    rxIpc.runCommand(IPC_CHANNEL, mainWindowRef.webContents, settings)
+    rxIpc.runCommand(IPC_CHANNEL_PUB, mainWindowRef.webContents, settings)
       .subscribe(
         (returnData) => {
             // no return data
@@ -305,9 +282,38 @@ const emitConfiguration = () => {
 }
 
 
+const destroyIpcChannels = () => {
+  rxIpc.removeListeners(IPC_CHANNEL_PUB);
+  rxIpc.removeListeners(IPC_CHANNEL_LISTEN);
+}
+
+
+const initializeIpcChannels = (mainWindow) => {
+  if (mainWindowRef === null) {
+    mainWindowRef = mainWindow;
+  }
+  destroyIpcChannels();
+
+  rxIpc.registerListener(IPC_CHANNEL_PUB, () => {
+    let settings = getConfiguration();
+    return Observable.create(observer => {
+      observer.next(settings);
+      observer.complete();
+    });
+  });
+
+  rxIpc.registerListener(IPC_CHANNEL_LISTEN, () => {
+    emitConfiguration();
+    return Observable.create(observer => {
+      observer.complete(true);
+    });
+  });
+}
+
+
 exports.getConfiguration = getConfiguration;
-exports.init = initializeIpcListener;
-exports.destroy = removeIpcListener;
+exports.init = initializeIpcChannels;
+exports.destroy = destroyIpcChannels;
 exports.getSettings = getSettings;
 exports.saveSettings = saveSettings;
 exports.send = emitConfiguration;

--- a/modules/daemon/daemonConfig.js
+++ b/modules/daemon/daemonConfig.js
@@ -270,7 +270,7 @@ const emitConfiguration = () => {
             // no return data
         },
         (error) => {
-          log.error("configuration emit error: error: " + error);
+          log.error("configuration emit error: " + error);
         },
         () => {
             // no logging

--- a/modules/daemon/daemonConfig.js
+++ b/modules/daemon/daemonConfig.js
@@ -289,9 +289,7 @@ const destroyIpcChannels = () => {
 
 
 const initializeIpcChannels = (mainWindow) => {
-  if (mainWindowRef === null) {
-    mainWindowRef = mainWindow;
-  }
+  mainWindowRef = mainWindow;
   destroyIpcChannels();
 
   rxIpc.registerListener(IPC_CHANNEL_PUB, () => {

--- a/modules/init.js
+++ b/modules/init.js
@@ -19,7 +19,6 @@ exports.start = function (mainWindow) {
   rpc.init();
   notification.init();
   closeGui.init();
-  daemonConfig.init(mainWindow);
   daemon.init();
 
   /* Initialize ZMQ */

--- a/preload.js
+++ b/preload.js
@@ -61,6 +61,7 @@ window.ipc = new SafeIpcRenderer([
   'zmq',
   'rpc-channel',
   'rpc-configuration',
+  'request-configuration',
 
   'rx-ipc-check-reply',
   'rx-ipc-check-listener'

--- a/src/app/core/rpc/rpc.service.ts
+++ b/src/app/core/rpc/rpc.service.ts
@@ -127,7 +127,7 @@ export class RpcService implements OnDestroy {
   private daemonListener(config: any): Observable<any> {
     return Observable.create(observer => {
       const isValid = config.auth && (config.auth !== this.authorization);
-      this.log.d(`Recieved RPC configuration: details are valid: ${isValid}`);
+      this.log.d(`Received RPC configuration: details are valid: ${isValid}`);
       if (isValid) {
         this.hostname = config.rpcbind || 'localhost';
         this.port = config.port ? config.port : this.port;

--- a/src/app/core/rpc/rpc.service.ts
+++ b/src/app/core/rpc/rpc.service.ts
@@ -47,10 +47,11 @@ export class RpcService implements OnDestroy {
     private _ipc: IpcService
   ) {
     this.isElectron = false;  // window.electron
-    if (environment.isTesting) {
+    if (environment.isTesting || !window.electron) {
       this.isInitialized = true;
     } else {
       this._ipc.registerListener(this.DAEMON_CHANNEL, this.daemonListener.bind(this));
+      this.requestConfiguration();
     }
   }
 
@@ -125,7 +126,9 @@ export class RpcService implements OnDestroy {
 
   private daemonListener(config: any): Observable<any> {
     return Observable.create(observer => {
-      if (config.auth && (config.auth !== this.authorization)) {
+      const isValid = config.auth && (config.auth !== this.authorization);
+      this.log.d(`Recieved RPC configuration: details are valid: ${isValid}`);
+      if (isValid) {
         this.hostname = config.rpcbind || 'localhost';
         this.port = config.port ? config.port : this.port;
         this.authorization = config.auth ? config.auth : this.authorization;
@@ -135,6 +138,17 @@ export class RpcService implements OnDestroy {
       // complete
       observer.complete();
     });
+  }
+
+  private requestConfiguration(): void {
+    setTimeout(() => {
+      this.log.d('Checking if RPC configuration is valid');
+      if (!this.isInitialized) {
+        this.log.d('Requesting valid RPC configuration');
+        this._ipc.runCommand('request-configuration', null, null);
+        this.requestConfiguration();
+      }
+    }, 5000);
   }
 
 }

--- a/src/app/wallet/wallet/shared/transaction.service.ts
+++ b/src/app/wallet/wallet/shared/transaction.service.ts
@@ -165,11 +165,14 @@ export class TransactionService implements OnDestroy {
     Object.keys(this.filters).map(filter => options[filter] = this.filters[filter]);
 
     this.rpc.call('filtertransactions', [options])
-      .subscribe((txResponse: Array<Object>) => {
-        this.log.d(`countTransactions, number of transactions after filter: ${txResponse.length}`);
-        this.txCount = txResponse.length;
-        return;
-      });
+      .subscribe(
+        (txResponse: Array<Object>) => {
+          this.log.d(`countTransactions, number of transactions after filter: ${txResponse.length}`);
+          this.txCount = txResponse.length;
+          return;
+        },
+        (err) => this.log.d('filtertransactions call failed!')
+      );
   }
 
   // TODO: remove shitty hack


### PR DESCRIPTION
This change ensures that the angular RpcService fetches the daemon connection configuration from the main process rather than waiting for it to simply be emitted..

This fixes such issues where, for example, development live reload or making use of the 'Close Window' window command restarts the renderer process which then waits indefinitely for RPC connection details and appears that the daemon is no longer connected/running.