### PR TITLE
Update to blind balance conversions

### DIFF
--- a/src/app/wallet/wallet/send/send.component.html
+++ b/src/app/wallet/wallet/send/send.component.html
@@ -52,13 +52,13 @@
   </div><!-- .page-intro -->
 
   <div fxLayout="row" fxLayoutGap="35px">
-  
+
     <div class="from-box" fxFlex="0 0 320px">
       <div class="sticky">
         <div class="section-title">Pay from</div>
         <mat-card>
           <!-- Select "FROM" balance/account -->
-          <mat-radio-group class="from-balance-type block-radio" name="sendInput" [(ngModel)]="send.input" 
+          <mat-radio-group class="from-balance-type block-radio" name="sendInput" [(ngModel)]="send.input"
                             fxLayout="column" fxLayoutGap="10px" (change)="updateAmount()">
             <mat-radio-button class="balance" value="part" checked="checked" color="primary"
                               (change)="setInputOutput('part', 'output')" fxFlex >
@@ -67,8 +67,8 @@
             </mat-radio-button>
             <mat-radio-button class="balance" value="blind" fxFlex color="primary" (change)="setInputOutput('blind', 'output')" >
               <div class="name">Blind</div>
-              <div class="desc">Available balance:<span *ngIf="!checkBalance('blind')" class="amount">{{ availableBalance('blind') }}</span>
-                <mat-icon *ngIf="checkBalance('blind')" fontSet="partIcon" fontIcon="part-circle-question" class="help-icon"
+              <div class="desc">Available balance:<span class="amount">{{ balanceDisplay('blind') }}</span>
+                <mat-icon *ngIf="showBalanceHelp('blind')" fontSet="partIcon" fontIcon="part-circle-question" class="help-icon"
                           matTooltip="It is normal to have a very small balance in Blind even after transferring out everything. This is due to the way CT works and part of the privacy platform."></mat-icon>
               </div>
             </mat-radio-button>
@@ -77,7 +77,7 @@
               <div class="desc">Available balance:<span class="amount">{{ availableBalance('anon') }}</span></div>
             </mat-radio-button>
           </mat-radio-group><!-- .from-balance-type -->
-    
+
           <!-- TX info help -->
           <p class="widget-help" *ngIf="send.input === 'part'">
             In public transactions, everything is visible on the blockchain &ndash; transaction amount, sender and receiver addresses.
@@ -89,7 +89,7 @@
             Anon transaction offer the highest privacy &ndash; transaction amounts and not even sender and receiver
             addresses are publicly visible. The higher privacy level is, the larger fee needs to be paid. Advanced users can further adjust the number of ring signatures.
           </p>
-    
+
           <!-- Show privacy slider if anonymous TX -->
           <div *ngIf="send.input === 'anon' && advanced" class="advanced">
             <div class="subtitle">Privacy level <small>(no. of ring sigs)</small></div>
@@ -117,7 +117,7 @@
                   matTooltipPosition="below">Highest
                 </span>
               </div><!-- .privacy-labels -->
-    
+
               <mat-slider
                 thumbLabel
                 color="primary"
@@ -126,7 +126,7 @@
                 [max]="32"
                 [value]="send.ringsize">
               </mat-slider>
-    
+
               <!-- set default value after clicking the button (8 signatures?) -->
               <button
                 (click)="setPrivacy(8)"
@@ -160,9 +160,8 @@
             </mat-radio-button>
             <mat-radio-button class="balance" value="blind" color="primary" (change)="setInputOutput('blind', 'input')" [disabled]="send.input === 'blind'" fxFlex>
               <div class="name">Blind</div>
-              <div class="desc">Available balance:<span *ngIf="!checkBalance('blind')"
-                                              class="amount">{{ availableBalance('blind') }}</span>
-                <mat-icon *ngIf="checkBalance('blind')" fontSet="partIcon" fontIcon="part-circle-question"
+              <div class="desc">Available balance:<span class="amount">{{ balanceDisplay('blind') }}</span>
+                <mat-icon *ngIf="showBalanceHelp('blind')" fontSet="partIcon" fontIcon="part-circle-question"
                           class="help-icon"
                           matTooltip="It is normal to have a very small balance in Blind even after transferring out everything. This is due to the way CT works and part of the privacy platform."></mat-icon>
               </div>

--- a/src/app/wallet/wallet/send/send.component.ts
+++ b/src/app/wallet/wallet/send/send.component.ts
@@ -91,18 +91,16 @@ export class SendComponent implements OnInit {
     if (balance === 'balance') {
       return new Amount(this.sendService.availableBalance, 8).getAmount();
     }
-    return this._rpcState.get('getwalletinfo')[balance] || 0;
+    return (this._rpcState.get('getwalletinfo') || {})[balance] || 0;
   }
 
-  getBalanceString(account: TxType): string {
-    const balance = this.txTypeToBalanceType(account);
-    return this._rpcState.get('getwalletinfo')[balance];
+  balanceDisplay(account: TxType): string {
+    return new Amount(this.availableBalance(account)).getAmountAsString();
   }
 
-  checkBalance(account: TxType): boolean {
-    if (account === TxType.BLIND) {
-      return parseFloat(this.getBalanceString(account)) < 0.0001 && parseFloat(this.getBalanceString(account)) > 0;
-    }
+  showBalanceHelp(account: TxType): boolean {
+    const amount = this.availableBalance(account);
+    return (amount < 0.0001) &&  (amount > 0);
   }
 
   private txTypeToBalanceType(type: TxType): string {

--- a/src/app/wallet/wallet/send/send.service.ts
+++ b/src/app/wallet/wallet/send/send.service.ts
@@ -118,7 +118,15 @@ export class SendService {
   }
 
   private rpc_send_failed(message: string, address?: string, amount?: number) {
-    this.flashNotification.open(`Transaction Failed ${message}`, 'err');
+    const idx = message.indexOf(']'); // End brancket of string like '[wallet.dat] ...'
+    let msg = '';
+    if (idx > -1) {
+      msg = message.substring(idx + 1);
+    } else {
+      msg = message;
+    }
+
+    this.flashNotification.open(`Transaction failed: ${msg}`, 'err');
     this.log.er('rpc_send_failed, failed to execute transaction!');
     this.log.er(message);
 


### PR DESCRIPTION
* Strips the error message displayed to the user of the more 'technical' information returned from the daemon, if something goes wrong;
* Shows the entire blind balance, even when only a few partoshis (the help message indicates why a balance might exist here, so no point in hiding the amount).

The change is intended to fix issues: https://github.com/particl/particl-desktop/issues/1446 and https://github.com/particl/particl-desktop/issues/1429