### PR TITLE
GFX: Balances in sidebar

### DIFF
--- a/src/app/core-ui/main/main-view.component.html
+++ b/src/app/core-ui/main/main-view.component.html
@@ -4,6 +4,20 @@
 
     <div class="logo">
       <img src="./assets/particl-logo{{testnet ? '-testnet' : ''}}.svg" alt="Particl">
+      <table class="balances" cellspacing="0">
+        <tr>
+          <th>Spendable</th>
+          <td>23,516<small>.5114</small></td>
+        </tr>
+        <tr>
+          <th>Locked</th>
+          <td>7,842<small>.4491</small></td>
+        </tr>
+        <tr>
+          <th>Total balance</th>
+          <td>31,358<small>.3991</small></td>
+        </tr>
+      </table>
     </div>
 
     <mat-divider></mat-divider>

--- a/src/app/core-ui/main/main-view.component.scss
+++ b/src/app/core-ui/main/main-view.component.scss
@@ -163,11 +163,61 @@ a.sidebar-item-link {
 
   .logo {
     flex: 0 0 50px;
-    display: block;
-    width: 130px;
-    margin: 35px auto;
+    position: relative;
+    &:hover {
+      img {
+        opacity: 0;
+      }
+      .balances {
+        opacity: 1;
+      }
+    }
     img {
+      @extend %tfx;
+      width: 130px;
+      display: block;
+      margin: 35px auto;
+    }
+    .balances {
+      @extend %tfx;
+      opacity: 0;
       width: 100%;
+      margin: auto;
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      font-size: 12.5px;
+      tr {
+        &:hover {
+          th,
+          td {
+            background: darken($bg-black, 1.5%);
+          }
+          td {
+            color: $color;
+            small {
+              color: darken($color, 15%);
+            }
+          }
+        }
+      }
+      th {
+        @extend %tfx;
+        text-align: left;
+        font-weight: 400;
+        padding: 5px 10px 5px 30px;
+      }
+      td {
+        @extend %tfx;
+        text-align: right;
+        font-weight: 500;
+        padding: 5px 30px 5px 10px;
+        small {
+          color: $text-muted;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Related to #1453 and [PBD-249](https://particl.atlassian.net/browse/PBD-249), this is a proposal for always reachable overview of balances.

After much thinking and experimenting, I believe this is a way to go:

![sidebar-balances](https://user-images.githubusercontent.com/1965795/54547299-b8c72080-49a5-11e9-907b-84c020ce7d42.gif)

The logo section is always visible (even on smaller screens), it doesn't scroll. I decided to go only with "locked, spendable & total balances" in the end. I don't think knowing exactly how much Blind/Anon/staking balance is necessary at all times – when you're sending those, you have the balance preview on Send page anyway (in other cases you don't need them at all).

Coded only statically so far, if you agree with this, it's ready for dev implementation.