### PR TITLE
Tweaks: Overview balances, price decimals

### DIFF
--- a/src/app/core-ui/main/main-view.component.scss
+++ b/src/app/core-ui/main/main-view.component.scss
@@ -211,9 +211,6 @@ a.sidebar-item-link {
         text-align: right;
         font-weight: 500;
         padding: 5px 24px 5px 10px;
-        small {
-          color: $text-muted;
-        }
       }
     }
   }

--- a/src/app/market/listings/listing-item/listing-item.component.scss
+++ b/src/app/market/listings/listing-item/listing-item.component.scss
@@ -77,10 +77,16 @@
   .price {
     font-weight: 500;
     font-size: 13px;
+    .point,
+    .small {
+      @extend %lighter;
+      font-size: 11px;
+    }
     .mat-icon {
       font-size: 11px;
       position: relative;
       top: 1px;
+      margin-left: 4px;
     }
   }
   button.to-cart {

--- a/src/app/wallet/overview/overview.component.html
+++ b/src/app/wallet/overview/overview.component.html
@@ -1,38 +1,40 @@
 <mat-card class="balance-overview">
-  <div class="total balance-item">
+  <div class="balance-item">
     <app-balance type="total_balance"></app-balance>
   </div>
-  <div class="total balance-item">
-    <app-balance type="actual_balance"></app-balance>
-  </div>
-  <div class="public balance-item">
+  <div class="balance-item">
     <app-balance type="balance"></app-balance>
   </div>
-  <div class="blind balance-item">
+  <div class="balance-item">
     <app-balance type="blind_balance"></app-balance>
   </div>
-  <div *ngIf="testnet" class="anon balance-item">
+  <div class="balance-item" *ngIf="testnet">
     <app-balance type="anon_balance"></app-balance>
   </div>
-  <div class="stake balance-item">
-    <app-balance type="staked_balance"></app-balance>
-  </div>
+  <table class="balances by-status" cellspacing="0">
+    <tr>
+      <th>Spendable</th>
+      <td><app-balance type="actual_balance" [inSidebar]="true"></app-balance></td>
+    </tr>
+    <tr>
+      <th>Locked</th>
+      <td><app-balance type="locked_balance" [inSidebar]="true"></app-balance></td>
+    </tr>
+    <tr>
+      <th>Staking</th>
+      <td><app-balance type="staked_balance" [inSidebar]="true"></app-balance></td>
+    </tr>
+  </table>
 </mat-card>
 
 
 <div class="overview">
   <div class="overview-content">
     <!-- @TODO comment out the code for widget for total listing, sell orders -->
-    <!-- <div class="seller-overview to-do">
-      <app-header>
-        <ul class="header-nav">
-          <li>Seller overview</li>
-          li class="buttons">
-            <mat-icon class="icon" fontSet="partIcon" fontIcon="part-cog" matTooltip="Edit widget"></mat-icon>
-            <mat-icon class="icon move" fontSet="partIcon" fontIcon="part-hamburger" matTooltip="Move widget"></mat-icon>
-          </li
-        </ul>
-      </app-header>
+    <!--div class="seller-overview section">
+      <header>
+        <div class="subtitle">Seller overview</div>
+      </header>
       <mat-card fxLayout>
         <div class="list listings" fxFlex="1 1 50%" fxLayout>
           <div class="total" fxFlex="1 1 40%">
@@ -44,7 +46,7 @@
             <div class="item"><div class="value">1</div><div class="desc">Expired</div></div>
             <div class="item"><div class="value">0</div><div class="desc">Unpublished</div></div>
           </div>
-        </div>.list.listings
+        </div>
         <div class="list orders" fxFlex="1 1 50%" fxLayout>
           <div class="total" fxFlex="1 1 40%">
             <div class="value">12</div>
@@ -55,9 +57,9 @@
             <div class="item"><div class="value">1</div><div class="desc">In escrow</div></div>
             <div class="item"><div class="value">3</div><div class="desc">Shipped</div></div>
           </div>
-        </div>.list.orders
+        </div>
       </mat-card>
-    </div>.seller-overview -->
+    </div><!-- .seller-overview -->
 
     <div class="recent-transactions section">
       <header>
@@ -78,16 +80,10 @@
 
   <div class="overview-sidebar">
     <!-- @TODO comment out the code for widget for total buy orders -->
-    <!-- <div class="buy-orders to-do">
-      <app-header>
-        <ul class="header-nav">
-          <li>Your buy orders</li>
-          li class="buttons">
-            <mat-icon class="icon" fontSet="partIcon" fontIcon="part-cog" matTooltip="Edit widget"></mat-icon>
-            <mat-icon class="icon move" fontSet="partIcon" fontIcon="part-hamburger" matTooltip="Move widget"></mat-icon>
-          </li
-        </ul>
-      </app-header>
+    <!--div class="buy-orders section">
+      <header>
+        <div class="subtitle">Your buy orders</div>
+      </header>
       <mat-card class="list orders" fxLayout>
         <div class="total" fxFlex="1 1 40%">
           <div class="value">5</div>
@@ -98,8 +94,8 @@
           <div class="item"><div class="value">0</div><div class="desc">In escrow</div></div>
           <div class="item"><div class="value">2</div><div class="desc">Shipped</div></div>
         </div>
-      </mat-card>.list.orders
-    </div>.buy-orders -->
+      </mat-card>
+    </div><!-- .buy-orders -->
 
     <app-coldstake></app-coldstake>
     <app-stakinginfo></app-stakinginfo>

--- a/src/app/wallet/overview/overview.component.scss
+++ b/src/app/wallet/overview/overview.component.scss
@@ -16,12 +16,14 @@
   table.balances {
     flex: 1 0 200px;
     th {
-      font-weight: 500;
+      @extend %lighter;
+      font-weight: 400;
       text-align: left;
       line-height: 1.45;
     }
     td {
       text-align: right;
+      font-weight: 500;
     }
   }
 }

--- a/src/app/wallet/overview/overview.component.scss
+++ b/src/app/wallet/overview/overview.component.scss
@@ -1,7 +1,7 @@
 @import './src/assets/_config'; // import shared colors etc.
 @import 'widgets/shared/shared.scss';
 
-.balance-overview { // list of balances
+.balance-overview {
   display: flex;
   margin-top: $header-main-height;
   padding: 24px 35px;
@@ -11,11 +11,17 @@
   .balance-item {
     border-right: 1px solid $bg-shadow;
     margin-right: 3%;
-    flex: 0 1 200px;
-    &:last-of-type {
-      border: 0;
-      margin: none;
-      margin-right: 0;
+    flex: 1 1 250px;
+  }
+  table.balances {
+    flex: 1 0 200px;
+    th {
+      font-weight: 500;
+      text-align: left;
+      line-height: 1.45;
+    }
+    td {
+      text-align: right;
     }
   }
 }

--- a/src/app/wallet/wallet/balances/balance.component.scss
+++ b/src/app/wallet/wallet/balances/balance.component.scss
@@ -25,7 +25,6 @@
   }
   & > .description {
     color: $text-muted;
-    text-transform: uppercase;
     margin-top: 6px;
   }
 
@@ -33,7 +32,8 @@
   &.in-sidebar {
     padding: 0;
     small {
-      opacity: 0.7;
+      @extend %lighter;
+      font-weight: 400;
     }
   }
 

--- a/src/app/wallet/wallet/balances/balance.component.ts
+++ b/src/app/wallet/wallet/balances/balance.component.ts
@@ -44,17 +44,17 @@ export class BalanceComponent implements OnInit, OnDestroy {
       case 'total_balance':
         return 'TOTAL BALANCE';
       case 'actual_balance':
-        return 'SPENDABLE';
+        return 'Spendable';
       case 'balance':
-        return 'PUBLIC';
+        return 'Public';
       case 'anon_balance':
-        return 'PRIVATE';
+        return 'Anon (Private)';
       case 'blind_balance':
-        return 'BLIND';
+        return 'Blind (Private)';
       case 'staked_balance':
-        return 'STAKING';
+        return 'Staking';
       case 'locked_balance':
-        return 'LOCKED';
+        return 'Locked';
     }
 
     return this.type;


### PR DESCRIPTION
### Done

- styled decimals on Listings overview
- after playing with it, I've decided _not to_ style the price in Listing's modal itself
- since Overview page was becoming crowded, I've moved the "by status" breakdown of balances aside + unified naming of Private => Anon (as we use it on Send page)

![Screenshot from 2019-03-28 15-49-19](https://user-images.githubusercontent.com/1965795/55167464-52928880-5171-11e9-9b55-91e1f541c0e0.png)

### Ready for upcoming PRs..

I've also updated the prepared sections in Overview for Market stuff (Listing/Order overview for Sellers & Orders for Buyers), which I've updated to latest code. Feel free to uncomment and implement somewhere in the future ;)

If anybody wonders how that looks like:

![Screenshot from 2019-03-28 15-56-52](https://user-images.githubusercontent.com/1965795/55167917-2592a580-5172-11e9-90b6-e69686c8e20c.png)