### PR TITLE
Fixes the client version information not being selectable.

### DIFF
--- a/src/app/core-ui/main/version/version.component.html
+++ b/src/app/core-ui/main/version/version.component.html
@@ -3,7 +3,7 @@
     Client
     <span class="version" [ngClass]="isUpdateProcessing ? 'unknown' : (isClientLatest ? 'current' : 'outdated')" [matTooltip]=" clientUpdateText " matTooltipPosition="right">
       <span class="dot"></span>
-      <span class="version" style="user-select: text;">{{ clientVersion }}</span>
+      <span class="selectable">{{ clientVersion }}</span>
     </span>
   </div>
   <div class="client item">

--- a/src/app/core-ui/main/version/version.component.html
+++ b/src/app/core-ui/main/version/version.component.html
@@ -3,7 +3,7 @@
     Client
     <span class="version" [ngClass]="isUpdateProcessing ? 'unknown' : (isClientLatest ? 'current' : 'outdated')" [matTooltip]=" clientUpdateText " matTooltipPosition="right">
       <span class="dot"></span>
-      {{ clientVersion }}
+      <span class="version" style="user-select: text;">{{ clientVersion }}</span>
     </span>
   </div>
   <div class="client item">

--- a/src/app/core-ui/main/version/version.component.scss
+++ b/src/app/core-ui/main/version/version.component.scss
@@ -18,6 +18,10 @@
       color: $color-white;
     }
 
+    .selectable {
+      @extend %enable-select;
+    }
+
     // version check indicator
     .dot {
       @extend %tfx;


### PR DESCRIPTION
While the remainder of the version information presented in the desktop application (bottom left corner currently) is user selectable, the Client version only is not. Appears to be due to the inclusion of the mattooltip, which adds a user-select style to the element, overriding any other styles or css attributes. This change simply works around that problem.