### PR TITLE
Fixes errorneous display of 'seller rejected bid' notification

### DIFF
--- a/src/app/core/util/utils.ts
+++ b/src/app/core/util/utils.ts
@@ -285,7 +285,7 @@ export const Messages = {
       'status_info': 'Seller rejected bid on this item, order has been cancelled (no money was spent)'
     },
     'sell': {
-      'action_button': 'Order rejected',
+      'action_button': 'Rejected order',
       'tooltip': '',
       'action_icon': 'part-error',
       'action_disabled': true,


### PR DESCRIPTION
Occurs when the seller rejects the bid: the seller receives a notification that the "seller rejected the bid"
This simply fixes this by changing the action button label for the seller to ensure that the matching on whether to display a notification does not occur.

Simplest fix :)