### PR TITLE
Additional check to remove potentially uncleaned daemon auth cookie file

### DIFF
--- a/modules/market/market.js
+++ b/modules/market/market.js
@@ -1,9 +1,9 @@
 const log = require('electron-log');
 const config = require('../daemon/daemonConfig');
+const cookie = require('../rpc/cookie');
 const market = require('particl-marketplace');
 const rxIpc = require('rx-ipc-electron/lib/main').default;
 const Observable = require('rxjs/Observable').Observable;
-const marketConfig = require('./config.js');
 
 // Stores the child process
 let child = undefined;
@@ -31,13 +31,15 @@ exports.start = function(walletName) {
     log.info('market process starting.');
 
     const isTestnet = Boolean(+_options.testnet);
+    const cookieFile = cookie.getCookieName(_options);
 
     const marketOptions = {
       ELECTRON_VERSION: process.versions.electron,
-      WALLET: walletName || '',
+      WALLET: String(walletName) || '',
       RPCHOSTNAME: _options.rpcbind || 'localhost',
       RPC_PORT: _options.port,
-      TESTNET: isTestnet
+      TESTNET: isTestnet,
+      RPCCOOKIEFILE: cookieFile
     };
 
     if (isTestnet) {

--- a/modules/rpc/cookie.js
+++ b/modules/rpc/cookie.js
@@ -97,16 +97,13 @@ function getAuth(options) {
   }
 
   let auth;
-  var dataDir = getParticlPath(options);
-  const COOKIE_FILE = dataDir
-                    + (options.testnet ? '/testnet' : '')
-                    + '/.cookie';
+  const COOKIE_PATH = getCookiePath(options);
 
-  if (fs.existsSync(COOKIE_FILE)) {
-    auth = fs.readFileSync(COOKIE_FILE, 'utf8').trim();
+  if (fs.existsSync(COOKIE_PATH)) {
+    auth = fs.readFileSync(COOKIE_PATH, 'utf8').trim();
   } else {
     auth = undefined;
-    log.debug('could not find cookie file! path:', COOKIE_FILE);
+    log.debug('could not find cookie file! path:', COOKIE_PATH);
   }
 
   return (auth)
@@ -116,5 +113,21 @@ function getParticlPath(options) {
   return options.datadir ? options.datadir : findCookiePath();
 }
 
+function getCookieName(options) {
+  return options.rpccookiefile ? options.rpccookiefile : `.cookie`;
+}
+
+function getCookiePath(options) {
+  let dataDir = getParticlPath(options);
+  const segments = [dataDir];
+  if (options.testnet) {
+    segments.push('testnet');
+  }
+  segments.push(getCookieName(options));
+  return path.join(...segments);
+}
+
 exports.getAuth = getAuth;
 exports.getParticlPath = getParticlPath;
+exports.getCookieName = getCookieName;
+exports.getCookiePath = getCookiePath;


### PR DESCRIPTION
Adds a (what should be redundant) check to the application startup to remove cookie files from a previous incorrect daemon shutdown.

Also passes `rpccookiefile` startup option as an environment variable to the marketplace in case of a user provided name for the daemon auth rpc cookie file (corresponding marketplace Pull request to add the environment variable is https://github.com/particl/particl-market/pull/387 .