### PR TITLE
Updates daemon cookie auth file removal if improperly shutdown previously.

### DIFF
--- a/main.js
+++ b/main.js
@@ -26,6 +26,7 @@ const log     = require('./modules/logger').init();
 const init    = require('./modules/init');
 const _auth = require('./modules/webrequest/http-auth');
 
+daemonConfig.deleteAuthFile();
 const options = daemonConfig.getConfiguration();
 
 // Keep a global reference of the window object, if you don't, the window will

--- a/modules/daemon/daemon.js
+++ b/modules/daemon/daemon.js
@@ -9,7 +9,6 @@ const _options = require('../options');
 const rpc = require('../rpc/rpc');
 const daemonManager = require('../daemon/daemonManager');
 const daemonConfig = require('./daemonConfig');
-const cookie = require('../rpc/cookie');
 
 let daemon = undefined;
 
@@ -68,24 +67,6 @@ exports.start = function (doReindex = false) {
     if (!(daemonSettings.global && daemonSettings.global.addressindex === 1)) {
       daemonConfig.saveSettings({addressindex: true});
       doReindex = true;
-    }
-  }
-
-  if (attemptsToStart === 0) {
-    let success = true;
-    log.info('Checking if cookie file exists (from incorrect shutdown)...');
-    // On startup, cleanup any leftover cookie file (which prevents proper daemon startup)
-    const cookiePath = cookie.getCookiePath(options);
-    try {
-      fs.unlinkSync(cookiePath);
-    } catch (err) {
-      if (err && err.code !== 'ENOENT') {
-        log.error('Failed to remove existing cookie file!!');
-        success = false;
-      }
-    }
-    if (success) {
-      log.info('Cookie file check completed successfully');
     }
   }
 

--- a/modules/daemon/daemonConfig.js
+++ b/modules/daemon/daemonConfig.js
@@ -309,9 +309,23 @@ const initializeIpcChannels = (mainWindow) => {
 }
 
 
+const deleteAuthFile = () => {
+  let settings = getConfiguration();
+  cookie.clearCookieFilePath(settings);
+  if ('auth' in STORED_CONFIGURATION) {
+    try {
+      delete STORED_CONFIGURATION.auth;
+    } catch (err) {
+      STORED_CONFIGURATION.auth = null;
+    }
+  }
+}
+
+
 exports.getConfiguration = getConfiguration;
 exports.init = initializeIpcChannels;
 exports.destroy = destroyIpcChannels;
 exports.getSettings = getSettings;
 exports.saveSettings = saveSettings;
 exports.send = emitConfiguration;
+exports.deleteAuthFile = deleteAuthFile;

--- a/modules/init.js
+++ b/modules/init.js
@@ -16,7 +16,6 @@ const market        = require('./market/market');
 
 exports.start = function (mainWindow) {
   // Initialize IPC listeners
-  rpc.init();
   notification.init();
   closeGui.init();
   daemon.init();
@@ -59,7 +58,9 @@ daemonManager.on('status', (status, msg) => {
     multiwallet.get()
     // TODO: activate for prompting wallet
     .then(chosenWallets => {
-      daemon.start();
+      daemon.start().then(() => {
+        rpc.init();
+      });
     })
     .then(() => {
       daemonConfig.send();

--- a/modules/rpc/cookie.js
+++ b/modules/rpc/cookie.js
@@ -109,6 +109,28 @@ function getAuth(options) {
   return (auth)
 }
 
+
+function clearCookieFilePath(options) {
+  let success = true;
+  log.info('Checking if cookie file exists (from incorrect shutdown)...');
+  const cookiePath = getCookiePath(options);
+  try {
+    if (fs.existsSync(cookiePath)) {
+      fs.unlinkSync(cookiePath);
+      log.info('Cleared existing cookie file...');
+    }
+  } catch (err) {
+    if (err && err.code !== 'ENOENT') {
+      log.error('Failed to remove existing cookie file!!');
+      success = false;
+    }
+  }
+  if (success) {
+    log.info('Cookie file check completed successfully');
+  }
+
+}
+
 function getParticlPath(options) {
   return options.datadir ? options.datadir : findCookiePath();
 }
@@ -130,4 +152,4 @@ function getCookiePath(options) {
 exports.getAuth = getAuth;
 exports.getParticlPath = getParticlPath;
 exports.getCookieName = getCookieName;
-exports.getCookiePath = getCookiePath;
+exports.clearCookieFilePath = clearCookieFilePath;


### PR DESCRIPTION
Now RPC authentication correctly uses the new auth file connection details rather than the removed files details (if an auth file previously existed).