### PR TITLE
Adds startup check for core v0.18.0.6

### DIFF
--- a/src/app/core/rpc/rpc.service.ts
+++ b/src/app/core/rpc/rpc.service.ts
@@ -40,6 +40,8 @@ export class RpcService implements OnDestroy {
    */
   private port: number = environment.particlPort;
 
+  private daemonProto: number = 0;
+
   // note: password basic64 equiv= dGVzdDp0ZXN0
   private authorization: string = btoa('test:test');
 
@@ -63,6 +65,22 @@ export class RpcService implements OnDestroy {
 
   get enabled(): boolean {
     return this.isInitialized;
+  }
+
+  set daemonProtocol(protocol: number) {
+    /*
+      @TODO (zaSmilingIdiot 2019-05-03):
+        This shouldn't be set externally, but since we are doing a connection check elsewhere,
+        but need to store this on a singleton instance, this is the quickest (dirtiest) place to put this.
+        Fix this!!
+    */
+   if (!this.daemonProto) {
+    this.daemonProto = +protocol;
+   }
+  }
+
+  get daemonProtocol(): number {
+    return this.daemonProto;
   }
 
   /**

--- a/src/app/installer/errors/error.component.html
+++ b/src/app/installer/errors/error.component.html
@@ -1,0 +1,52 @@
+<div class="terms">
+
+  <div class="mini-sidebar"></div>
+
+  <div class="sidebar">
+    <div class="logo">
+      <img src="./assets/particl-logo{{testnet ? '-testnet' : ''}}.svg" alt="Particl">
+    </div>
+
+    <mat-divider></mat-divider>
+
+    <div class="progress">
+      <div class="step last active">
+        <div class="number">1</div>
+        <div class="desc">Startup Error</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="content">
+    <mat-toolbar class="header-main">
+      Could not continue with the application startup
+    </mat-toolbar><!-- .header-main -->
+
+    <div class="container-block">
+      <div class="page-intro">
+        <h1>An error occurred</h1>
+        <div class="content">
+          <p>
+            Please ensure that your Particl Core version is at least using protocol version 90008
+          </p>
+        </div>
+      </div><!-- .page-intro -->
+
+      <div class="terms-text">
+        <p> We've detected that the Particl Core version currently running does not meet the minimum version requirement of v0.18.0.6</p>
+        <p> if you are running the the core version manually, please update it before trying again. Alternatively, you may close this application and relaunch it in order to retry the automatic download and start.</p>
+      </div>
+    </div>
+
+    <div class="action-buttons" fxLayoutAlign="space-between center">
+      <div class="right">
+        <button mat-button color="warn" matTooltip="Particl Desktop will be closed" (click)="quitApp()">
+          <mat-icon class="icon" fontSet="partIcon" fontIcon="part-cross"></mat-icon>
+          Decline &amp; Close
+        </button>
+      </div>
+    </div>
+  <!-- .content -->
+  </div>
+</div>
+<!-- .terms -->

--- a/src/app/installer/errors/error.component.scss
+++ b/src/app/installer/errors/error.component.scss
@@ -1,0 +1,188 @@
+@import './src/assets/_config'; // import shared colors etc.
+
+$installer-minisidebar-width: 54px;
+$installer-sidebar-width: (270px - $installer-minisidebar-width);
+$installer-sidebar-padding: 30px;
+$installer-header-height: 96px;
+
+.container-block {
+  margin-top: $header-main-height;
+  .page-intro {
+    p {
+      margin-bottom: 0;
+    }
+  }
+}
+
+.mat-divider { // section divider
+  border-bottom: 1px solid lighten($bg-black, 5%);
+  border-top: 1px solid darken($bg-black, 5%);
+}
+
+.progress {
+  margin-left: -15px;
+  padding: 30px 0;
+  .step {
+    margin-bottom: 16px;
+    position: relative;
+    .number {
+      $size: 28px;
+      display: inline-block;
+      background: lighten($bg-black, 10%);
+      width: $size;
+      height: $size;
+      border-radius: 50%;
+      text-align: center;
+      line-height: $size;
+      position: relative;
+      z-index: 10;
+    }
+    .desc {
+      display: inline-block;
+      font-size: 13px;
+      text-transform: uppercase;
+      margin-left: 16px;
+      color: darken($bg, 50%);
+    }
+    &:not(.last):after { // lines connecting numbers
+      content: '';
+      display: block;
+      background: lighten($bg-black, 5%);
+      width: 2px;
+      position: absolute;
+      top: 12px;
+      bottom: -24px;
+      left: 13px;
+      z-index: 1;
+    }
+    &.active { // active steps
+      .number {
+        background: $color;
+        font-weight: 700;
+        color: $bg-black;
+      }
+      .desc {
+        color: $bg;
+        font-weight: 600;
+      }
+    }
+    &.done { // finished steps
+      &:after {
+        background: rgba($color, 0.2);
+      }
+      .number {
+        background: mix($color, $bg-black);
+        color: $bg-black;
+      }
+      .desc {
+        font-weight: 400;
+        color: rgba($bg, 0.8);
+      }
+    }
+  }
+}
+
+.terms {
+  @extend %disable-select;
+  & > .mini-sidebar {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: $installer-minisidebar-width;
+    background: darken($bg-black, 5%);
+  }
+  & > .sidebar {
+    width: $installer-sidebar-width;
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: $installer-minisidebar-width;
+    background: $bg-black;
+    color: $bg;
+    .logo {
+      display: flex;
+      height: 120px;
+      img {
+        display: block;
+        margin: auto;
+      }
+    }
+  }
+  & > .content {
+    background: $bg;
+    margin-left: ($installer-sidebar-width + $installer-minisidebar-width);
+    .header-main {
+      border-bottom: 1px solid $bg-shadow;
+      background: $color-white;
+      padding-left: 35px;
+      padding-right: 26px;
+      font-size: 15px;
+      font-weight: 700;
+      text-transform: uppercase;
+      position: fixed;
+      top: 0;
+      left: ($installer-minisidebar-width + $installer-sidebar-width);
+      right: 0;
+      z-index: 100;
+    }
+  }
+}
+
+.terms-text {
+  text-align: justify;
+  line-height: 1.5;
+}
+
+.action-buttons {
+  margin: 6px 35px 35px;
+  &.huge {
+    margin: 15px 0 0;
+    display: flex;
+    align-items: stretch;
+    .half {
+      @extend %tfx;
+      flex: 1 1 50%;
+      text-align: center;
+      margin: 0;
+      padding: 36px 46px 46px;
+      .icon {
+        @extend %tfx;
+        font-size: 38px;
+        color: $bg-shadow;
+      }
+      .choice-title {
+        font-size: 15px;
+        text-transform: uppercase;
+        font-weight: 700;
+        margin: 14px 0 12px;
+      }
+      .choice-desc {
+        margin: 8px 0 26px;
+        color: $text-muted;
+      }
+      &:hover {
+        background: $color-white;
+        &.create {
+          .icon {
+            transform: scale(1.1);
+            color: $color;
+          }
+        }
+        &.restore {
+          .icon {
+            transform: rotate(45deg) scale(1.1);
+            color: $color-info;
+          }
+        }
+      }
+      &:last-of-type {
+        margin-left: 30px;
+      }
+    }
+  }
+}
+
+.confirmation-checkbox {
+  margin-right: 12px;
+}

--- a/src/app/installer/errors/error.component.spec.ts
+++ b/src/app/installer/errors/error.component.spec.ts
@@ -1,0 +1,33 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ErrorComponent } from './error.component';
+import { CoreModule } from '../../core/core.module';
+import { SharedModule } from '../../wallet/shared/shared.module';
+import { CoreUiModule } from '../../core-ui/core-ui.module';
+
+describe('TermsComponent', () => {
+  let component: ErrorComponent;
+  let fixture: ComponentFixture<ErrorComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        SharedModule,
+        CoreModule.forRoot(),
+        CoreUiModule.forRoot()
+       ],
+      declarations: [ ErrorComponent ],
+      providers: []
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ErrorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/installer/errors/error.component.ts
+++ b/src/app/installer/errors/error.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { CloseGuiService } from 'app/core/close-gui/close-gui.service';
+
+@Component({
+  selector: 'app-terms',
+  templateUrl: './error.component.html',
+  styleUrls: ['./error.component.scss']
+})
+export class ErrorComponent {
+  constructor(
+    private close: CloseGuiService
+  ) { }
+
+  quitApp(): void {
+    this.close.quitElectron();
+  }
+
+}

--- a/src/app/installer/installer.module.ts
+++ b/src/app/installer/installer.module.ts
@@ -11,6 +11,7 @@ import { InstallerRouterComponent } from './installer.router';
 import { CreateWalletComponent } from './create-wallet/create-wallet.component';
 import { PassphraseComponent } from 'app/installer/create-wallet/passphrase/passphrase.component';
 import { TermsComponent } from './terms/terms.component';
+import { ErrorComponent } from './errors/error.component';
 
 @NgModule({
   imports: [
@@ -25,7 +26,8 @@ import { TermsComponent } from './terms/terms.component';
     InstallerRouterComponent,
     CreateWalletComponent,
     PassphraseComponent,
-    TermsComponent
+    TermsComponent,
+    ErrorComponent
   ],
   schemas: [CUSTOM_ELEMENTS_SCHEMA]
 })

--- a/src/app/installer/installer.router.ts
+++ b/src/app/installer/installer.router.ts
@@ -3,6 +3,7 @@ import { Component } from '@angular/core';
 // import { EncryptWalletComponent } from './encrypt-wallet/encrypt-wallet.component';
 import { CreateWalletComponent } from './create-wallet/create-wallet.component';
 import { TermsComponent } from './terms/terms.component';
+import { ErrorComponent } from './errors/error.component';
 
 @Component({
   templateUrl: './installer.router.html',
@@ -17,5 +18,6 @@ export const installer_routing = {
     { path: '', redirectTo: 'create', pathMatch: 'full' },
     { path: 'create', component: CreateWalletComponent },
     { path: 'terms', component: TermsComponent },
+    { path: 'error', component: ErrorComponent },
   ]
 };


### PR DESCRIPTION
Stops use of the application if the core version is less than the minimum required v0.18.0.6.

With the release of core v0.18.x functionality such as the restart of the daemon to encrypt a created/restored wallet is no longer necessary. Hence a node needs to make use of a 0.18 version minimum.
Another change in 0.18.0.6 is that smsgmessages cannot be received from nodes running a core version less than 0.18.0.6. With the alpha mainnet release of the marketplace running on at least core v0.18.0.6 it is imperative, for the marketplace, to have the local node running this version.
While the desktop client will be released with at least this version bundled (or rather, automatically downloaded on startup), this change ensures that attempts to start this version with an existing running node on a lower version does not break the application.