### PR TITLE
Adds buttons to a transaction history row for easier use.

### DIFF
--- a/src/app/main-wallet/shared/transaction-table/transaction-table.component.html
+++ b/src/app/main-wallet/shared/transaction-table/transaction-table.component.html
@@ -29,6 +29,12 @@
           {{ txn.formattedTime }}
         </div>
 
+        <div>
+          <button *ngIf="!txn.isAbandoned && (txn.confirmations === 0) && (txn.category === 'send' || txn.category === 'internal_transfer')" mat-button color="warn" class="small" appDebounceClick (debounceClick)="abandonTransaction(txn.txid)" matTooltip="Abandon this transaction" matTooltipPosition="above">
+            <mat-icon fontIcon="part-error"></mat-icon>
+          </button>
+        </div>
+
         <!-- Category icon -->
         <div class="type">
 
@@ -209,7 +215,7 @@
             </ng-template>
           </th>
           <td>
-            <span class="value enable-select">{{ txn.netAmount}} PART</span>
+            <span class="value enable-select">{{ txn.netAmount }} PART</span>
           </td>
         </tr>
       </table><!-- .tx-details -->
@@ -218,13 +224,17 @@
 
     <mat-action-row class="action-buttons" fxLayout fxLayoutAlign="space-between stretch">
       <div class="left">
-        <button *ngIf="!txn.isAbandoned && (txn.confirmations === 0) && txn.category === 'send'" mat-button color="warn" class="small" appDebounceClick (debounceClick)="abandonTransaction(txn.txid)">
+        <button *ngIf="!txn.isAbandoned && (txn.confirmations === 0) && (txn.category === 'send' || txn.category === 'internal_transfer')" mat-button color="warn" class="small" appDebounceClick (debounceClick)="abandonTransaction(txn.txid)">
           <mat-icon fontIcon="part-error"></mat-icon>
           Abandon This Transaction
         </button>
       </div>
 
       <div class="right">
+        <button mat-button color="basic" class="small" ngxClipboard [cbContent]="txn.address" (click)="copyToClipBoard()">
+          <mat-icon fontIcon="part-copy"></mat-icon>
+          Copy Address
+        </button>
         <button mat-button color="basic" class="small" ngxClipboard [cbContent]="txn.txid" (click)="copyToClipBoard()">
           <mat-icon fontIcon="part-copy"></mat-icon>
           Copy TX ID

--- a/src/app/main-wallet/shared/transaction-table/transaction-table.component.ts
+++ b/src/app/main-wallet/shared/transaction-table/transaction-table.component.ts
@@ -15,7 +15,7 @@ import { WalletURLState } from '../state-store/wallet-store.state';
 
 enum TextContent {
   FETCH_ERROR = 'An error occurred while fetching the transactions',
-  TXID_COPIED = 'TX ID copied to the cliboard',
+  TXID_COPIED = 'Copied to the cliboard',
   TX_ABANDON_SUCCESS = 'Successfully abandoned tx: {txid}',
   TX_ABANDON_ERROR = 'Failed to abandon/cancel that transaction',
 }


### PR DESCRIPTION
Adds an 'Abandon Transaction' button to the row header to more quicker abandon a transaction. While the button was available in the expanded history, this adds the button to the parent row for convenience. Additionally, allows for abandoning an internal transfer (conversion) transction, rather than just send transactions.

Adds a button to allow for copying of the transaction address (the address to/from which the transaction targets). The ability to copy the address already exists via double-click to highlight the visible part of the address, ctrl/cmd-C. This however, is hidden from GUI users, so a button has been added for this purpose. While right-click style context menus would be useful, those suffer from their own issues:
  - has similar discoverability issues (although maybe to a slightly lesser extent) as the current double-click ctrl-C style copy;
  - is more complicated to include as a feature currently due to electron and safely integrating node and related 'backend' API directly into the window. The context menus can be investigated as part of a future discussion.